### PR TITLE
feat(WinBox): add background color for body

### DIFF
--- a/src/components/BootstrapBlazor.WinBox/BootstrapBlazor.WinBox.csproj
+++ b/src/components/BootstrapBlazor.WinBox/BootstrapBlazor.WinBox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.1</Version>
+    <Version>9.0.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.WinBox/wwwroot/css/winbox.bundle.css
+++ b/src/components/BootstrapBlazor.WinBox/wwwroot/css/winbox.bundle.css
@@ -8,6 +8,7 @@
     --bb-winbox-bg: #b5b5c3;
     --bb-winbox-bg-dark: #383b3f;
     --bb-winbox-body-padding: .5rem;
+    --bb-winbox-body-bg: var(--bs-body-bg);
     --bb-window-border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
     --bb-winbox-footer-border-color: var(--bs-border-color);
     --bb-winbox-mask-bg: #000;
@@ -16,7 +17,7 @@
 }
 
     .winbox .wb-body {
-        background-color: var(--bb-winbox-bg);
+        background-color: var(--bb-winbox-body-bg);
     }
 
     .winbox .bb-winbox-content {


### PR DESCRIPTION
# add background color for body

Summary of the changes (Less than 80 chars)

## Description

fixes #127 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

New Features:
- Introduce a new CSS variable '--bb-winbox-body-bg' to set the background color for the WinBox body.