### PR TITLE
feat(MeiliSearch): add display none on first render logic

### DIFF
--- a/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
+++ b/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.1-beta01</Version>
+    <Version>9.0.1-beta03</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.cs
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.cs
@@ -34,7 +34,7 @@ public partial class MeiliSearchBox
     [Parameter]
     public string? SearchResultPlaceHolder { get; set; }
 
-    private string? ClassString => CssBuilder.Default("bb-g-search")
+    private string? ClassString => CssBuilder.Default("bb-g-search d-none")
         .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
@@ -3,10 +3,11 @@ import Data from "../BootstrapBlazor/modules/data.js"
 import EventHandler from "../BootstrapBlazor/modules/event-handler.js"
 
 export async function init(id, options) {
-    await addLink('./_content/BootstrapBlazor.MeiliSearch/meilisearch.css')
-    await addScript('./_content/BootstrapBlazor.MeiliSearch/meilisearch.umd.min.js')
-
     const el = document.getElementById(id);
+    await addLink('./_content/BootstrapBlazor.MeiliSearch/meilisearch.css');
+    el.classList.remove('d-none');
+
+    await addScript('./_content/BootstrapBlazor.MeiliSearch/meilisearch.umd.min.js')
     const search = {
         el, options,
         searchText: 'searching ...',


### PR DESCRIPTION
# add display none on first render logic

Summary of the changes (Less than 80 chars)

## Description

fixes #134 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

New Features:
- Implement logic to hide the MeiliSearch component on initial render by adding 'd-none' class.