### PR TITLE
refactor(WinBox): move style variable to root

### DIFF
--- a/src/components/BootstrapBlazor.WinBox/BootstrapBlazor.WinBox.csproj
+++ b/src/components/BootstrapBlazor.WinBox/BootstrapBlazor.WinBox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.4</Version>
+    <Version>9.0.5</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.WinBox/WinBox.razor.js
+++ b/src/components/BootstrapBlazor.WinBox/WinBox.razor.js
@@ -1,6 +1,5 @@
 ﻿import './js/winbox.min.js'
 import Data from '../BootstrapBlazor/modules/data.js'
-import EventHanlder from '../BootstrapBlazor/modules/event-handler.js'
 import { addLink } from "../BootstrapBlazor/modules/utility.js"
 
 export async function init(id) {

--- a/src/components/BootstrapBlazor.WinBox/wwwroot/css/winbox.bundle.css
+++ b/src/components/BootstrapBlazor.WinBox/wwwroot/css/winbox.bundle.css
@@ -1,6 +1,6 @@
 ﻿@import url('./winbox.min.css');
 
-.winbox {
+:root {
     --bb-winbox-bg: #b5b5c3;
     --bb-winbox-bg-dark: #383b3f;
     --bb-winbox-body-bg: var(--bs-body-bg);
@@ -9,6 +9,9 @@
     --bb-winbox-body-padding: .5rem;
     --bb-window-border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
     --bb-winbox-footer-border-color: var(--bs-border-color);
+}
+
+.winbox {
     background: var(--bb-winbox-bg);
     border-radius: var(--bb-window-border-radius);
 }


### PR DESCRIPTION
# move style variable to root

Summary of the changes (Less than 80 chars)

## Description

fixes #140 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Move style variables to the root in the CSS file for better maintainability.