### PR TITLE
refactor(MeiliSearch): add search-key style instead of key

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BBVersion>9.0.*</BBVersion>
+    <BBVersion>9.0.0</BBVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
+++ b/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.2</Version>
+    <Version>9.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
+++ b/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.1</Version>
+    <Version>9.0.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
@@ -187,7 +187,7 @@ const updateList = (search, result) => {
 
 const highlight = (text, query) => {
     const regex = new RegExp(query, 'i');
-    return text.replace(regex, `<key>${query}</key>`);
+    return text.replace(regex, `<i class=\"search-key\">${query}</i>`);
 }
 
 const updateStatus = (search, hits, ms) => {

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
@@ -166,10 +166,8 @@ const updateList = (search, result) => {
 
         if (hit.demos) {
             const ul = document.createElement('ol');
-            ul.classList.add('mb-0');
-            ul.classList.add('mt-2')
             hit.demos.forEach(block => {
-                const li = document.createElement('ul');
+                const li = document.createElement('li');
                 const url = block.url || hit.url;
                 li.innerHTML = blockHtml.replace('{url}', url)
                     .replace('{title}', highlight(block.title, result.query))

--- a/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
+++ b/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
@@ -2,7 +2,6 @@
     --bb-global-search-color: rgba(255,255,255,.5);
     --bb-global-search-border-color: rgba(255,255,255,.5);
     --bb-global-search-border-hover-color: rgba(255,255,255);
-    --bb-global-search-highlight-color: #0078d4;
 }
 
 .search-dialog-mask {
@@ -10,13 +9,19 @@
     --bb-global-search-item-hover-bg: rgba(var(--bs-emphasis-color-rgb), 0.1);
     --bb-global-search-dialog-input-focus-border-color: rgba(var(--bs-emphasis-color-rgb), 0.4);
     --bb-global-search-dialog-mask-z-index: 1100;
+    --bb-global-search-highlight-color: #0078d4;
 }
 
-    .search-dialog-mask key {
+    .search-dialog-mask .search-dialog-item ol {
+        margin: .5rem 0 0 0;
+    }
+
+    .search-dialog-mask .search-key {
         display: inline-block;
         margin: 0;
         color: var(--bb-global-search-highlight-color);
         font-weight: bold;
+        font-style: normal;
     }
 
 .bb-g-search {

--- a/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
+++ b/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
@@ -8,7 +8,7 @@
     --bb-global-search-item-active-bg: rgba(var(--bs-emphasis-color-rgb), 0.2);
     --bb-global-search-item-hover-bg: rgba(var(--bs-emphasis-color-rgb), 0.1);
     --bb-global-search-dialog-input-focus-border-color: rgba(var(--bs-emphasis-color-rgb), 0.4);
-    --bb-global-search-dialog-mask-z-index: 1100;
+    --bb-global-search-dialog-mask-z-index: 1092;
     --bb-global-search-highlight-color: #0078d4;
 }
 

--- a/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
+++ b/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
@@ -11,6 +11,13 @@
     --bb-global-search-dialog-mask-z-index: 1100;
 }
 
+    .search-dialog-mask key {
+        display: inline-block;
+        margin: 0;
+        color: var(--bb-primary-color);
+        font-weight: bold;
+    }
+
 .bb-g-search {
     display: flex;
     align-items: center;

--- a/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
+++ b/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
@@ -2,6 +2,7 @@
     --bb-global-search-color: rgba(255,255,255,.5);
     --bb-global-search-border-color: rgba(255,255,255,.5);
     --bb-global-search-border-hover-color: rgba(255,255,255);
+    --bb-global-search-highlight-color: #0078d4;
 }
 
 .search-dialog-mask {
@@ -14,7 +15,7 @@
     .search-dialog-mask key {
         display: inline-block;
         margin: 0;
-        color: var(--bb-primary-color);
+        color: var(--bb-global-search-highlight-color);
         font-weight: bold;
     }
 


### PR DESCRIPTION
# add search-key style instead of key

Summary of the changes (Less than 80 chars)

## Description

fixes #147 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Refactor the MeiliSearch component to use 'search-key' style instead of 'key' for highlighting search queries.