### PR TITLE
refactor(WinBox): use HeadContent render style link

### DIFF
--- a/src/components/BootstrapBlazor.Gantt/Components/Gantt.razor
+++ b/src/components/BootstrapBlazor.Gantt/Components/Gantt.razor
@@ -4,7 +4,7 @@
 @attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.Gantt/Components/Gantt.razor.js", JSObjectReference = true)]
 
 <HeadContent>
-    <link href="_content/BootstrapBlazor.Gantt/css/gantt.bundle.css" rel="stylesheet" />
+    <link rel="stylesheet" href="_content/BootstrapBlazor.Gantt/css/gantt.bundle.css" />
 </HeadContent>
 
 <div @attributes="@AdditionalAttributes" id="@Id" class="@ClassString">

--- a/src/components/BootstrapBlazor.WinBox/BootstrapBlazor.WinBox.csproj
+++ b/src/components/BootstrapBlazor.WinBox/BootstrapBlazor.WinBox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.5</Version>
+    <Version>9.0.6</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.WinBox/WinBox.razor
+++ b/src/components/BootstrapBlazor.WinBox/WinBox.razor
@@ -1,6 +1,11 @@
-﻿@namespace BootstrapBlazor.Components
+﻿@using Microsoft.AspNetCore.Components.Web
+@namespace BootstrapBlazor.Components
 @inherits BootstrapModuleComponentBase
-@attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.WinBox/WinBox.razor.js", JSObjectReference = true)]
+@attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.WinBox/WinBox.razor.js", JSObjectReference = true, AutoInvokeInit = false)]
+
+<HeadContent>
+    <link rel="stylesheet" href="_content/BootstrapBlazor.WinBox/css/winbox.bundle.css" />
+</HeadContent>
 
 <CascadingValue Value="CloseAsync" IsFixed="true">
     @foreach (var (key, option) in _cache)

--- a/src/components/BootstrapBlazor.WinBox/WinBox.razor.js
+++ b/src/components/BootstrapBlazor.WinBox/WinBox.razor.js
@@ -1,10 +1,5 @@
 ﻿import './js/winbox.min.js'
 import Data from '../BootstrapBlazor/modules/data.js'
-import { addLink } from "../BootstrapBlazor/modules/utility.js"
-
-export async function init(id) {
-    await addLink('./_content/BootstrapBlazor.WinBox/css/winbox.bundle.css')
-}
 
 export function show(id, invoke, option) {
     const el = document.getElementById(id);


### PR DESCRIPTION
# use HeadContent render style link

Summary of the changes (Less than 80 chars)

## Description

fixes #175 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Refactor WinBox component to use HeadContent for rendering style links.