### PR TITLE
refactor(MeiliSearch): use HeadContent render static assets

### DIFF
--- a/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
+++ b/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.5</Version>
+    <Version>9.0.6</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor
@@ -1,6 +1,12 @@
-﻿@namespace BootstrapBlazor.Components
+﻿@using Microsoft.AspNetCore.Components.Web
+@namespace BootstrapBlazor.Components
 @inherits BootstrapModuleComponentBase
 @attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js")]
+
+<HeadContent>
+    <link href="_content/BootstrapBlazor.MeiliSearch/meilisearch.css" rel="stylesheet" />
+    <script src="_content/BootstrapBlazor.MeiliSearch/meilisearch.umd.min.js"></script>
+</HeadContent>
 
 <div @attributes="@AdditionalAttributes" id="@Id" class="@ClassString">
     <i class="fa-solid fa-search"></i>

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
@@ -1,4 +1,4 @@
-﻿import { addScript, addLink, debounce, isMobile } from "../BootstrapBlazor/modules/utility.js"
+﻿import { debounce, isMobile } from "../BootstrapBlazor/modules/utility.js"
 import Data from "../BootstrapBlazor/modules/data.js"
 import EventHandler from "../BootstrapBlazor/modules/event-handler.js"
 
@@ -6,12 +6,10 @@ if (window.BootstrapBlazor === void 0) {
     window.BootstrapBlazor = {};
 }
 
-export async function init(id, options) {
+export function init(id, options) {
     const el = document.getElementById(id);
-    await addLink('./_content/BootstrapBlazor.MeiliSearch/meilisearch.css');
     el.classList.remove('d-none');
 
-    await addScript('./_content/BootstrapBlazor.MeiliSearch/meilisearch.umd.min.js')
     const search = {
         el, options,
         searchText: 'searching ...',


### PR DESCRIPTION
# use HeadContent render static assets

Summary of the changes (Less than 80 chars)

## Description

fixes #178 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Refactor MeiliSearchBox component to use HeadContent for rendering static assets.