### PR TITLE
refactor(WinBox): revert use addLink process static assets

### DIFF
--- a/src/components/BootstrapBlazor.WinBox/BootstrapBlazor.WinBox.csproj
+++ b/src/components/BootstrapBlazor.WinBox/BootstrapBlazor.WinBox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.6</Version>
+    <Version>9.0.7</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.WinBox/WinBox.razor
+++ b/src/components/BootstrapBlazor.WinBox/WinBox.razor
@@ -1,11 +1,6 @@
-﻿@using Microsoft.AspNetCore.Components.Web
-@namespace BootstrapBlazor.Components
+﻿@namespace BootstrapBlazor.Components
 @inherits BootstrapModuleComponentBase
-@attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.WinBox/WinBox.razor.js", JSObjectReference = true, AutoInvokeInit = false)]
-
-<HeadContent>
-    <link rel="stylesheet" href="_content/BootstrapBlazor.WinBox/css/winbox.bundle.css" />
-</HeadContent>
+@attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.WinBox/WinBox.razor.js", JSObjectReference = true)]
 
 <CascadingValue Value="CloseAsync" IsFixed="true">
     @foreach (var (key, option) in _cache)

--- a/src/components/BootstrapBlazor.WinBox/WinBox.razor.js
+++ b/src/components/BootstrapBlazor.WinBox/WinBox.razor.js
@@ -1,5 +1,10 @@
 ﻿import './js/winbox.min.js'
 import Data from '../BootstrapBlazor/modules/data.js'
+import { addLink } from "../BootstrapBlazor/modules/utility.js"
+
+export async function init(id) {
+    await addLink('_content/BootstrapBlazor.WinBox/css/winbox.bundle.css')
+}
 
 export function show(id, invoke, option) {
     const el = document.getElementById(id);


### PR DESCRIPTION
# revert use addLink process static assets

Summary of the changes (Less than 80 chars)

## Description

fixes #179 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Revert the use of the addLink function for processing static assets in the WinBox component.