### PR TITLE
refactor(SvgEditor): use HeadContent render static assets

### DIFF
--- a/src/components/BootstrapBlazor.SVGEditor/BootstrapBlazor.SvgEditor.csproj
+++ b/src/components/BootstrapBlazor.SVGEditor/BootstrapBlazor.SvgEditor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.SVGEditor/Components/SvgEditor/SvgEditor.razor
+++ b/src/components/BootstrapBlazor.SVGEditor/Components/SvgEditor/SvgEditor.razor
@@ -1,5 +1,10 @@
-﻿@namespace BootstrapBlazor.Components
+﻿@using Microsoft.AspNetCore.Components.Web
+@namespace BootstrapBlazor.Components
 @inherits BootstrapModuleComponentBase
 @attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.SvgEditor/Components/SvgEditor/SvgEditor.razor.js", JSObjectReference = true)]
+
+<HeadContent>
+    <link rel="stylesheet" href="./_content/BootstrapBlazor.SvgEditor/svgedit.bundle.css" />
+</HeadContent>
 
 <div class="bb-svg-editor svg-editor" id="@Id"></div>

--- a/src/components/BootstrapBlazor.SVGEditor/Components/SvgEditor/SvgEditor.razor.js
+++ b/src/components/BootstrapBlazor.SVGEditor/Components/SvgEditor/SvgEditor.razor.js
@@ -1,11 +1,9 @@
-﻿import { addLink } from '../../../BootstrapBlazor/modules/utility.js'
-import Data from '../../../BootstrapBlazor/modules/data.js'
+﻿import Data from '../../../BootstrapBlazor/modules/data.js'
 import Editor from "../../editor/Editor.js"
 
-export async function init(id, options) {
-    await addLink("./_content/BootstrapBlazor.SvgEditor/editor/svgedit.css")
-
+export function init(id, options) {
     const { preload, interop, callback } = options;
+
     /* for available options see the file `docs/tutorials/ConfigOptions.md */
     const svgEditor = new Editor(document.getElementById(id))
     svgEditor.setConfig({
@@ -14,7 +12,7 @@ export async function init(id, options) {
         allowInitialUserOverride: false,
         imgPath: "./_content/BootstrapBlazor.SvgEditor/editor/images/",
         showGrid: true,
-        extPath: "/_content/BootstrapBlazor.SvgEditor/editor/extensions/",
+        extPath: "./_content/BootstrapBlazor.SvgEditor/editor/extensions/",
         noDefaultExtensions: false
     })
     svgEditor.init()

--- a/src/components/BootstrapBlazor.SVGEditor/wwwroot/svgedit.bundle.css
+++ b/src/components/BootstrapBlazor.SVGEditor/wwwroot/svgedit.bundle.css
@@ -1,4 +1,6 @@
-﻿.svg-editor {
+﻿@import url('./editor/svgedit.css');
+
+.svg-editor {
     width: 100%;
     height: 600px;
     min-height: 600px


### PR DESCRIPTION
# use HeadContent render static assets

Summary of the changes (Less than 80 chars)

## Description

fixes #181 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Refactor SvgEditor component to use HeadContent for rendering static assets.