### PR TITLE
refactor(Gantt): update static assets link

### DIFF
--- a/src/components/BootstrapBlazor.Gantt/BootstrapBlazor.Gantt.csproj
+++ b/src/components/BootstrapBlazor.Gantt/BootstrapBlazor.Gantt.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.1</Version>
+    <Version>9.0.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Gantt/Components/Gantt.razor
+++ b/src/components/BootstrapBlazor.Gantt/Components/Gantt.razor
@@ -1,11 +1,6 @@
-﻿@using Microsoft.AspNetCore.Components.Web
-@namespace BootstrapBlazor.Components
+﻿@namespace BootstrapBlazor.Components
 @inherits BootstrapModuleComponentBase
 @attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.Gantt/Components/Gantt.razor.js", JSObjectReference = true)]
-
-<HeadContent>
-    <link rel="stylesheet" href="_content/BootstrapBlazor.Gantt/css/gantt.bundle.css" />
-</HeadContent>
 
 <div @attributes="@AdditionalAttributes" id="@Id" class="@ClassString">
     <svg></svg>

--- a/src/components/BootstrapBlazor.Gantt/Components/Gantt.razor.js
+++ b/src/components/BootstrapBlazor.Gantt/Components/Gantt.razor.js
@@ -8,7 +8,7 @@ export async function init(id, tasks, option, invoke) {
         return
     }
 
-    await addLink("./_content/BootstrapBlazor.Gantt/css/frappe-gantt.min.css")
+    await addLink("./_content/BootstrapBlazor.Gantt/css/gantt.bundle.css")
 
     const gantt = new Gantt(el, tasks, {
         on_click: function (task) {


### PR DESCRIPTION
# update static assets link

Summary of the changes (Less than 80 chars)

## Description

fixes #187 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Update the static asset link in the Gantt component to use 'gantt.bundle.css' instead of 'frappe-gantt.min.css'.