### PR TITLE
chore(TableExport): bump version 9.0.1

### DIFF
--- a/src/components/BootstrapBlazor.TableExport/BootstrapBlazor.TableExport.csproj
+++ b/src/components/BootstrapBlazor.TableExport/BootstrapBlazor.TableExport.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BootstrapBlazor" Version="$(BBVersion)" />
-    <PackageReference Include="MiniExcel" Version="1.34.2" />
+    <PackageReference Include="MiniExcel" Version="1.36.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
upgrade MinExcel to 1.36.0

# bump version 9.0.1

Summary of the changes (Less than 80 chars)

## Description

fixes #207 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Upgrade MinExcel dependency to version 1.36.0 to address issue #207.

Bug Fixes:
- Fixed issue #207.

Chores:
- Bumped project version to 9.0.1.