### PR TITLE
feat(MeiliSearch): dialog support ESC key

### DIFF
--- a/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
+++ b/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.1.3</Version>
+    <Version>9.1.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor
@@ -6,7 +6,7 @@
     <i class="fa-solid fa-search search-dialog-icon"></i>
     <input type="text" readonly placeholder="@SearchBoxPlaceHolder" />
     <div class="search-dialog-mask">
-        <div class="search-dialog shadow-lg">
+        <div class="search-dialog shadow-lg" tabindex="0">
             <header class="search-dialog-input">
                 <i class="fa-solid fa-search"></i>
                 <input type="text" placeholder="@SearchBoxPlaceHolder" />

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.cs
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.cs
@@ -137,6 +137,31 @@ public partial class MeiliSearchBox
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
+    /// <param name="firstRender"></param>
+    /// <returns></returns>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (!firstRender)
+        {
+            await InvokeVoidAsync("update", Id, new
+            {
+                Options.CurrentValue?.Url,
+                Options.CurrentValue?.ApiKey,
+                Index = $"{Options.CurrentValue?.Index}-{CultureInfo.CurrentUICulture.Name}",
+                SearchableColumns,
+                ScrollIntoViewOptions,
+                EmptySearchResultPlaceHolder,
+                SearchingText,
+                SearchResultText
+            });
+        }
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     /// <returns></returns>
     protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, new
     {

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
@@ -52,7 +52,7 @@ export function dispose(id) {
         const { el, menu, dialog, clearButton, input, mask } = search;
         EventHandler.off(clearButton, 'click');
         EventHandler.off(dialog, 'click');
-        EventHandler.off(input, 'keyup');
+        EventHandler.off(dialog, 'keyup');
         EventHandler.off(menu, 'click');
         EventHandler.off(el, 'click');
         EventHandler.off(mask, 'click');
@@ -90,11 +90,11 @@ const handlerClearButton = search => {
 }
 
 const handlerSearch = search => {
-    const { input, options, menu } = search;
+    const { input, dialog, options, menu } = search;
     const filter = {
         attributesToSearchOn: options.searchableColumns
     };
-    EventHandler.on(input, 'keyup', async e => {
+    EventHandler.on(dialog, 'keyup', async e => {
         if (e.key === 'Enter' || e.key === 'NumpadEnter') {
             const activeItem = search.list.querySelector('.active');
             if (activeItem) {

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
@@ -61,18 +61,18 @@ export function dispose(id) {
 }
 
 const handlerMask = search => {
-    const { mask } = search;
+    const { mask, dialog } = search;
     document.body.appendChild(mask);
     EventHandler.on(mask, 'click', e => {
         closeDialog();
     });
-}
-
-const handlerToggle = search => {
-    const { el, dialog, input } = search;
     EventHandler.on(dialog, 'click', e => {
         e.stopPropagation();
     });
+}
+
+const handlerToggle = search => {
+    const { el, input } = search;
     EventHandler.on(el, 'click', e => {
         document.documentElement.classList.toggle('bb-g-search-open');
         input.focus();

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
@@ -39,6 +39,11 @@ export async function init(id, options) {
     })
 }
 
+export function update(id, options) {
+    const search = Data.get(id);
+    search.options = options;
+}
+
 export function dispose(id) {
     const search = Data.get(id);
     Data.remove(id);

--- a/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
+++ b/src/components/BootstrapBlazor.MeiliSearch/wwwroot/meilisearch.css
@@ -5,7 +5,7 @@
     --bb-global-search-highlight-color: #0078d4;
     --bb-global-search-dialog-mask-z-index: 1092;
     --bb-global-search-footer-shadow: 0 -1px 0 0 #e0e3e8, 0 -3px 6px 0 rgba(69, 98, 155, .12);
-    --bb-global-search-main-max-height: calc(100vh - 180px);
+    --bb-global-search-main-max-height: calc(100vh - 260px);
     --bb-global-search-footer-kbd-bg: var(--bs-body-color);
     --bb-global-search-footer-kbd-color: var(--bs-body-bg);
 }


### PR DESCRIPTION
# dialog support ESC key

Summary of the changes (Less than 80 chars)

## Description

fixes #231 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Update the MeiliSearch dialog to support the ESC key for closing the dialog.

New Features:
- Add scrollIntoViewOptions parameter to MeiliSearch component to customize the scroll behavior.

Bug Fixes:
- Fix an issue where the ESC key was not closing the MeiliSearch dialog.

Enhancements:
- Update the MeiliSearch component to refresh its options when parameters change.