### PR TITLE
feat(Markdown): use Id instead of ElementReference

### DIFF
--- a/src/components/BootstrapBlazor.Markdown/BootstrapBlazor.Markdown.csproj
+++ b/src/components/BootstrapBlazor.Markdown/BootstrapBlazor.Markdown.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor
+++ b/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor
@@ -1,4 +1,4 @@
 ﻿@namespace BootstrapBlazor.Components
 @inherits ValidateBase<string>
 
-<div @attributes="@AdditionalAttributes" @ref="Element" class="@GetClassString()" />
+<div @attributes="@AdditionalAttributes" id="@Id" class="@GetClassString()" />

--- a/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.cs
+++ b/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.cs
@@ -82,11 +82,6 @@ public partial class Markdown : IAsyncDisposable
     private MarkdownOption Option { get; } = new();
 
     /// <summary>
-    /// 获得/设置 DOM 元素实例
-    /// </summary>
-    private ElementReference Element { get; set; }
-
-    /// <summary>
     /// 获得 组件样式
     /// </summary>
     protected string? GetClassString() => CssBuilder.Default()
@@ -116,7 +111,7 @@ public partial class Markdown : IAsyncDisposable
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Element, Interop, Option, nameof(Update));
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, Option, nameof(Update));
 
     /// <summary>
     /// 更新组件值方法
@@ -154,7 +149,7 @@ public partial class Markdown : IAsyncDisposable
     public new async Task SetValue(string value)
     {
         CurrentValueAsString = value;
-        await InvokeVoidAsync("update", Element, Value);
+        await InvokeVoidAsync("update", Id, Value);
     }
 
     /// <summary>
@@ -163,5 +158,5 @@ public partial class Markdown : IAsyncDisposable
     /// <param name="method"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
-    public Task DoMethodAsync(string method, params object[] parameters) => InvokeVoidAsync("invoke", Element, method, parameters);
+    public Task DoMethodAsync(string method, params object[] parameters) => InvokeVoidAsync("invoke", Id, method, parameters);
 }

--- a/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
+++ b/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
@@ -4,11 +4,12 @@ import '../../lib/tui.highlight/toastui-editor-plugin-code-syntax-highlight-all.
 import { addLink } from '../../../BootstrapBlazor/modules/utility.js'
 import Data from '../../../BootstrapBlazor/modules/data.js'
 
-export async function init(el, invoker, options, callback) {
+export async function init(id, invoker, options, callback) {
     await addLink('./_content/BootstrapBlazor.Markdown/css/bootstrap.blazor.markdown.min.css')
 
+    const el = document.getElementById(id)
     const md = {}
-    Data.set(el, md)
+    Data.set(id, md)
 
     md._invoker = invoker
     md._options = options
@@ -27,22 +28,22 @@ export async function init(el, invoker, options, callback) {
     })
 }
 
-export function update(el, val) {
-    const md = Data.get(el)
+export function update(id, val) {
+    const md = Data.get(id)
     md._editor.setMarkdown(val)
 }
 
-export function invoke(el, method, parameters) {
-    const md = Data.get(el)
+export function invoke(id, method, parameters) {
+    const md = Data.get(id)
     md._editor[method](...parameters);
     const val = md._editor.getMarkdown()
     const html = md._editor.getHTML()
     md._invoker.invokeMethodAsync('Update', [val, html])
 }
 
-export function dispose(el) {
-    const md = Data.get(el)
+export function dispose(id) {
+    const md = Data.get(id)
+    Data.remove(id)
     md._editor.off('blur')
     md._editor.destroy()
-    Data.remove(el)
 }


### PR DESCRIPTION
# use Id instead of ElementReference

Summary of the changes (Less than 80 chars)

## Description

fixes #251 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Use element ID instead of a direct reference for accessing Markdown editor instances.

Bug Fixes:
- Fixes an issue where the Markdown editor would not update correctly.

Enhancements:
- Improved the performance of the Markdown editor by using element IDs instead of direct references.