### PR TITLE
feat(AntDesignIcon): add Color parameter

### DIFF
--- a/src/components/BootstrapBlazor.AntDesignIcon/AntDesignIcon.razor
+++ b/src/components/BootstrapBlazor.AntDesignIcon/AntDesignIcon.razor
@@ -1,6 +1,6 @@
 ﻿@inherits BootstrapComponentBase
 @namespace BootstrapBlazor.Components
 
-<div @attributes="@AdditionalAttributes" class="@ClassString">
+<div @attributes="@AdditionalAttributes" class="@ClassString" style="@StyleString">
     <svg xmlns="http://www.w3.org/2000/svg"><use href="@Href"></use></svg>
 </div>

--- a/src/components/BootstrapBlazor.AntDesignIcon/AntDesignIcon.razor.cs
+++ b/src/components/BootstrapBlazor.AntDesignIcon/AntDesignIcon.razor.cs
@@ -25,6 +25,12 @@ public partial class AntDesignIcon
     public string? Href { get; set; }
 
     /// <summary>
+    /// 获得 图标颜色 默认 null 未设置
+    /// </summary>
+    [Parameter]
+    public string? Color { get; set; }
+
+    /// <summary>
     /// 获得 图标分类 默认为 Outlined    
     /// </summary>
     [Parameter]
@@ -35,6 +41,11 @@ public partial class AntDesignIcon
     /// </summary>
     private string? ClassString => CssBuilder.Default("bb-ant-icon")
         .AddClass($"bb-ant-icon-{Name}", !string.IsNullOrEmpty(Name))
+        .Build();
+
+    private string? StyleString => CssBuilder.Default()
+        .AddClass($"--bb-ant-icon-color: {Color};", !string.IsNullOrEmpty(Color) && Category != AntDesignIconCategory.TwoTone)
+        .AddStyleFromAttributes(AdditionalAttributes)
         .Build();
 
     /// <summary>

--- a/src/components/BootstrapBlazor.AntDesignIcon/AntDesignIcon.razor.css
+++ b/src/components/BootstrapBlazor.AntDesignIcon/AntDesignIcon.razor.css
@@ -1,14 +1,11 @@
 ﻿.bb-ant-icon {
     --bb-svg-icon-width: 16px;
-    --bb-svg-icon-color: var(--bs-body-color);
     display: inline-flex;
+    color: var(--bb-ant-icon-color, currentColor);
 }
 
     .bb-ant-icon > svg {
         width: var(--bb-svg-icon-width);
         height: var(--bb-svg-icon-width);
+        fill: currentColor;
     }
-
-        .bb-ant-icon > svg > * {
-            stroke: var(--bb-svg-icon-color);
-        }

--- a/src/components/BootstrapBlazor.AntDesignIcon/BootstrapBlazor.AntDesignIcon.csproj
+++ b/src/components/BootstrapBlazor.AntDesignIcon/BootstrapBlazor.AntDesignIcon.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0</Version>
+    <Version>9.0.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# add Color parameter

Summary of the changes (Less than 80 chars)

## Description

fixes #288 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

New Features:
- Allow setting the color of Ant Design icons using the `Color` parameter.