### PR TITLE
fix(SvgEditor): missing class when use HeadContent

### DIFF
--- a/src/components/BootstrapBlazor.SVGEditor/BootstrapBlazor.SvgEditor.csproj
+++ b/src/components/BootstrapBlazor.SVGEditor/BootstrapBlazor.SvgEditor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.2</Version>
+    <Version>9.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.SVGEditor/Components/SvgEditor/SvgEditor.razor
+++ b/src/components/BootstrapBlazor.SVGEditor/Components/SvgEditor/SvgEditor.razor
@@ -3,8 +3,4 @@
 @inherits BootstrapModuleComponentBase
 @attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.SvgEditor/Components/SvgEditor/SvgEditor.razor.js", JSObjectReference = true)]
 
-<HeadContent>
-    <link rel="stylesheet" href="_content/BootstrapBlazor.SvgEditor/svgedit.bundle.css" />
-</HeadContent>
-
-<div class="bb-svg-editor svg-editor" id="@Id"></div>
+<div @attributes="AdditionalAttributes" id="@Id" class="bb-svg-editor svg-editor"></div>

--- a/src/components/BootstrapBlazor.SVGEditor/Components/SvgEditor/SvgEditor.razor.js
+++ b/src/components/BootstrapBlazor.SVGEditor/Components/SvgEditor/SvgEditor.razor.js
@@ -1,8 +1,11 @@
-﻿import Data from '../../../BootstrapBlazor/modules/data.js'
+﻿import { addLink } from '../../../BootstrapBlazor/modules/utility.js'
+import Data from '../../../BootstrapBlazor/modules/data.js'
 import Editor from "../../editor/Editor.js"
 
-export function init(id, options) {
+export async function init(id, options) {
     const { preload, interop, callback } = options;
+
+    await addLink('_content/BootstrapBlazor.SvgEditor/svgedit.bundle.css');
 
     /* for available options see the file `docs/tutorials/ConfigOptions.md */
     const svgEditor = new Editor(document.getElementById(id))


### PR DESCRIPTION
# missing class when use HeadContent

Summary of the changes (Less than 80 chars)

## Description

fixes #300 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Load svgedit.bundle.css dynamically instead of using HeadContent.

Bug Fixes:
- Fixed missing styles when using HeadContent.

Enhancements:
- Improved CSS loading strategy.