### PR TITLE
bug(UniverSheet): throw exception when data is null

### DIFF
--- a/src/components/BootstrapBlazor.UniverSheet/BootstrapBlazor.UniverSheet.csproj
+++ b/src/components/BootstrapBlazor.UniverSheet/BootstrapBlazor.UniverSheet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0-beta04</Version>
+    <Version>9.0.0-beta05</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.UniverSheet/wwwroot/univer.js
+++ b/src/components/BootstrapBlazor.UniverSheet/wwwroot/univer.js
@@ -63,7 +63,7 @@ export async function createUniverSheetAsync(sheet) {
     });
 
     const { data } = sheet.options;
-    if (data !== void 0) {
+    if (data) {
         univerAPI.createWorkbook(JSON.parse(data.data));
         delete sheet.options.data;
     }


### PR DESCRIPTION
# throw exception when data is null

Summary of the changes (Less than 80 chars)
This pull request includes updates to versioning and a minor code improvement in the `BootstrapBlazor.UniverSheet` component.

Version update:

* [`src/components/BootstrapBlazor.UniverSheet/BootstrapBlazor.UniverSheet.csproj`](diffhunk://#diff-67a2cb20b06e470742b01783fb3da5efc6a40b537fd34f02aebb6311d20dce5aL4-R4): Updated the version from `9.0.0-beta04` to `9.0.0-beta05`.

Code improvement:

* [`src/components/BootstrapBlazor.UniverSheet/wwwroot/univer.js`](diffhunk://#diff-c411049485ffcd731c3233aa329319fbc9699e31115590001c26aff91878da28L66-R66): Simplified the check for `data` in the `createUniverSheetAsync` function by replacing `data !== void 0` with `data`.

## Description

fixes #350 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the application would not handle null data correctly in the UniverSheet component.