### PR TITLE
refactor(Script): use || instead of ||=

### DIFF
--- a/src/components/BootstrapBlazor.Html2Image/BootstrapBlazor.Html2Image.csproj
+++ b/src/components/BootstrapBlazor.Html2Image/BootstrapBlazor.Html2Image.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.1</Version>
+    <Version>9.0.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Html2Image/wwwroot/html2image.js
+++ b/src/components/BootstrapBlazor.Html2Image/wwwroot/html2image.js
@@ -4,7 +4,7 @@ export async function execute(selector, methodName, options) {
     let data = null;
     const el = document.querySelector(selector);
     if (el) {
-        options ||= {};
+        options = options || {};
         const fn = methodName === 'toBlob'
             ? htmlToImage[methodName]
             : getMethod(options);

--- a/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
+++ b/src/components/BootstrapBlazor.MeiliSearch/BootstrapBlazor.MeiliSearch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.1.8</Version>
+    <Version>9.1.9</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
+++ b/src/components/BootstrapBlazor.MeiliSearch/MeiliSearchBox.razor.js
@@ -138,7 +138,7 @@ const handlerSearch = search => {
     });
 }
 
-const getScrollIntoViewOptions = options => options.scrollIntoViewOptions ?? {
+const getScrollIntoViewOptions = options => options.scrollIntoViewOptions || {
     behavior: 'smooth',
     block: 'start',
     inline: 'nearest'

--- a/src/components/BootstrapBlazor.MindMap/BootstrapBlazor.MindMap.csproj
+++ b/src/components/BootstrapBlazor.MindMap/BootstrapBlazor.MindMap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.1.5</Version>
+    <Version>9.1.6</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.MindMap/MindMap.razor.js
+++ b/src/components/BootstrapBlazor.MindMap/MindMap.razor.js
@@ -16,7 +16,7 @@ export async function init(id, invoke, data, options) {
 
     Themes.init(MindMap);
 
-    options ||= {};
+    options = options || {};
     options.el = el;
     const d = JSON.parse(data);
     if (d.root === null) {

--- a/src/components/BootstrapBlazor.UniverSheet/BootstrapBlazor.UniverSheet.csproj
+++ b/src/components/BootstrapBlazor.UniverSheet/BootstrapBlazor.UniverSheet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0-beta06</Version>
+    <Version>9.0.0-beta07</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.UniverSheet/wwwroot/plugin.js
+++ b/src/components/BootstrapBlazor.UniverSheet/wwwroot/plugin.js
@@ -44,7 +44,7 @@ export class DefaultPlugin extends Plugin {
     }
 
     setWorkbookData(data) {
-        this._sheet ||= this._dataService.getUniverSheet();
+        this._sheet = this._sheet || this._dataService.getUniverSheet();
         const { univerAPI } = this._sheet;
         const activeWorkbook = univerAPI.getActiveWorkbook()
         const unitId = activeWorkbook?.getId()
@@ -55,7 +55,7 @@ export class DefaultPlugin extends Plugin {
     }
 
     getWorkbookData() {
-        this._sheet ||= this._dataService.getUniverSheet();
+        this._sheet = this._sheet || this._dataService.getUniverSheet();
         const { univerAPI } = this._sheet;
         const data = univerAPI.getActiveWorkbook().save();
         delete data.id;
@@ -71,7 +71,7 @@ export class DefaultPlugin extends Plugin {
     }
 
     updateRange(data) {
-        this._sheet ||= this._dataService.getUniverSheet();
+        this._sheet = this._sheet || this._dataService.getUniverSheet();
         const { univerAPI } = this._sheet;
         const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
         const range = sheet.getRange(data.range);


### PR DESCRIPTION
# use || instead of ||=

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #362 

## Customer Impact


## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the nullish coalescing assignment operator was causing errors in older browsers, as described in issue #362.