### PR TITLE
chore(Action): add issue check action

### DIFF
--- a/.github/workflows/issue-check-inactive.yml
+++ b/.github/workflows/issue-check-inactive.yml
@@ -1,0 +1,21 @@
+name: Issue Check Inactive
+
+on:
+  schedule:
+    - cron: "0 0 */15 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  issue-check-inactive:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-inactive
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'check-inactive'
+          inactive-label: 'inactive'
+          inactive-day: 7

--- a/.github/workflows/issue-check-inactive.yml
+++ b/.github/workflows/issue-check-inactive.yml
@@ -19,4 +19,8 @@ jobs:
           actions: 'check-inactive'
           token: ${{ secrets.GITHUB_TOKEN }}
           inactive-label: 'inactive'
-          inactive-day: 7
+          inactive-day: 3
+          body: |
+            Since the issue was labeled with `invalid`, but no response in 3 days. This issue will be closed. If you have any questions, you can comment and reply.
+
+            由于该 issue 被标记为不合规工程，却 3 天未收到回应。现关闭 issue，若有任何问题，可评论回复。

--- a/.github/workflows/issue-check-inactive.yml
+++ b/.github/workflows/issue-check-inactive.yml
@@ -17,5 +17,6 @@ jobs:
         uses: actions-cool/issues-helper@v3
         with:
           actions: 'check-inactive'
+          token: ${{ secrets.GITHUB_TOKEN }}
           inactive-label: 'inactive'
           inactive-day: 7

--- a/.github/workflows/issue-close-required.yml
+++ b/.github/workflows/issue-close-required.yml
@@ -1,0 +1,26 @@
+name: Issue Close Require
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  issue-close-require:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: needs repro project
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'need-repro-project'
+          inactive-day: 3
+          body: |
+            Since the issue was labeled with `need-repro-project`, but no response in 3 days. This issue will be closed. If you have any questions, you can comment and reply.
+
+            由于该 issue 被标记为需要复现工程，却 3 天未收到回应。现关闭 issue，若有任何问题，可评论回复。


### PR DESCRIPTION
## Link issues
fixes #375 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces two new GitHub Actions workflows to manage issues in the repository. These workflows automate the process of labeling inactive issues and closing issues that require a reproduction project but have not received a response within a specified time frame.

New GitHub Actions workflows:

* [`.github/workflows/issue-check-inactive.yml`](diffhunk://#diff-169c4342ef331a9ca8bee39f45668fd67b312f1a23cc5d74d6dca98a1dadb9d5R1-R21): Adds a workflow to label issues as inactive if there has been no activity for 7 days. This workflow runs every 15 days.
* [`.github/workflows/issue-close-required.yml`](diffhunk://#diff-96f1b7f845d3bb37beb68d59147bfbb178376fccf293fdf512afe24246d8f495R1-R26): Adds a workflow to close issues labeled with 'need-repro-project' if there has been no response within 3 days. This workflow runs daily.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Adds two new GitHub Actions workflows to automate issue management: one to label inactive issues and another to close issues awaiting reproduction projects.

CI:
- Adds a workflow to label issues as inactive if there has been no activity for 7 days, running every 15 days.
- Adds a workflow to close issues labeled with 'need-repro-project' if there has been no response within 3 days, running daily.