### PR TITLE
chore(DockView2): adjust the dockview side css style

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.1.9</Version>
+    <Version>9.1.10</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -209,11 +209,12 @@
     width: var(--bb-dockview-aside-width);
     display: flex;
     align-items: flex-start;
-    justify-content: center;
+    justify-content: start;
+    flex-direction: column;
 }
 
 .bb-dockview .bb-dockview-aside-left {
-    left: 0
+    left: 2px;
 }
 
 .bb-dockview .bb-dockview-aside-right {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -209,7 +209,7 @@
     width: var(--bb-dockview-aside-width);
     display: flex;
     align-items: flex-start;
-    justify-content: start;
+    justify-content: flex-start;
     flex-direction: column;
 }
 


### PR DESCRIPTION
## Link issues
fixes #402 

the effect after adjustment:
![image](https://github.com/user-attachments/assets/4f1072c5-1d3c-4a16-b735-952389627876)
![image](https://github.com/user-attachments/assets/8bb57e69-014a-47b1-bc93-af44f3e531b5)


<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Chores:
- Modify the CSS positioning and layout of the DockView aside panel to improve alignment and positioning