### PR TITLE
fix(Splitting): update style file path

### DIFF
--- a/src/components/BootstrapBlazor.Splitting/BootstrapBlazor.Splitting.csproj
+++ b/src/components/BootstrapBlazor.Splitting/BootstrapBlazor.Splitting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.2</Version>
+    <Version>9.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Splitting/Components/Splitting/Splitting.razor.js
+++ b/src/components/BootstrapBlazor.Splitting/Components/Splitting/Splitting.razor.js
@@ -51,7 +51,7 @@ const loader = el => {
 }
 
 export async function init(id) {
-    await addLink('./_content/BootstrapBlazor.Splitting/lib/splitting/splitting-cells.css')
+    await addLink('./_content/BootstrapBlazor.Splitting/splitting.bundle.css')
     await addScript('./_content/BootstrapBlazor.Splitting/lib/splitting/splitting.min.js')
     await addScript('./_content/BootstrapBlazor.Splitting/modules/gsap.min.js')
 


### PR DESCRIPTION
## Link issues
fixes #441 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix the CSS file reference for the Splitting component

Bug Fixes:
- Update Splitting.razor.js to load splitting.bundle.css instead of splitting-cells.css

Chores:
- Adjust BootstrapBlazor.Splitting.csproj to include the new CSS asset path