### PR TITLE
feat(PdfViewer): add OnLoaded parameter

### DIFF
--- a/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
+++ b/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0-beta01</Version>
+    <Version>9.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
@@ -23,6 +23,18 @@ public partial class PdfViewer
     [Parameter]
     public string? Height { get; set; }
 
+    /// <summary>
+    /// Gets or sets the document loaded event callback.
+    /// </summary>
+    [Parameter]
+    public Func<Task>? OnLoaded { get; set; }
+
+    /// <summary>
+    /// Gets or sets the document loaded event callback.
+    /// </summary>
+    [Parameter]
+    public Func<Task>? NotSupportCallback { get; set; }
+
     private string? ClassString => CssBuilder.Default("bb-pdf-viewer-container")
         .AddClassFromAttributes(AdditionalAttributes)
         .Build();
@@ -58,5 +70,35 @@ public partial class PdfViewer
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id);
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, new
+    {
+        LoadedCallaback = nameof(TriggerOnLoaded),
+        NotSupportCallback = nameof(TriggerNotSupportCallback)
+    });
+
+    /// <summary>
+    /// Trigger OnLoaded callback when the PDF document is loaded.
+    /// </summary>
+    /// <returns></returns>
+    [JSInvokable]
+    public async Task TriggerOnLoaded()
+    {
+        if (OnLoaded != null)
+        {
+            await OnLoaded();
+        }
+    }
+
+    /// <summary>
+    /// Trigger NotSupportCallback when the PDF viewer does not support the document.
+    /// </summary>
+    /// <returns></returns>
+    [JSInvokable]
+    public async Task TriggerNotSupportCallback()
+    {
+        if (NotSupportCallback != null)
+        {
+            await NotSupportCallback();
+        }
+    }
 }

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
@@ -6,6 +6,7 @@ export async function init(id, invoke, options) {
 
     if (!navigator.pdfViewerEnabled) {
         await invoke.invokeMethodAsync(options.notSupportCallback);
+        return;
     }
 
     const el = document.getElementById(id);

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
@@ -1,11 +1,15 @@
 ﻿import { addLink } from "../BootstrapBlazor/modules/utility.js"
 import Data from "../BootstrapBlazor/modules/data.js"
 
-export async function init(id) {
+export async function init(id, invoke, options) {
     await addLink("./_content/BootstrapBlazor.PdfViewer/pdf-viewer.css");
 
+    if (!navigator.pdfViewerEnabled) {
+        await invoke.invokeMethodAsync(options.notSupportCallback);
+    }
+
     const el = document.getElementById(id);
-    const pdfViewer = { el };
+    const pdfViewer = { el, invoke, options };
     Data.set(id, pdfViewer);
 
     const url = el.getAttribute('data-bb-url');
@@ -16,8 +20,13 @@ export function loadPdf(id, url) {
     const pdfViewer = Data.get(id);
     const { el } = pdfViewer;
     if (url) {
-        const { frame } = pdfViewer;
+        const { frame, invoke, options } = pdfViewer;
         const viewer = frame || createFrame(el);
+        if (options.loadedCallaback) {
+            viewer.onload = () => {
+                invoke.invokeMethodAsync(options.loadedCallaback);
+            };
+        }
         viewer.src = url;
     }
     else {

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
@@ -4,11 +4,6 @@ import Data from "../BootstrapBlazor/modules/data.js"
 export async function init(id, invoke, options) {
     await addLink("./_content/BootstrapBlazor.PdfViewer/pdf-viewer.css");
 
-    if (!navigator.pdfViewerEnabled) {
-        await invoke.invokeMethodAsync(options.notSupportCallback);
-        return;
-    }
-
     const el = document.getElementById(id);
     const pdfViewer = { el, invoke, options };
     Data.set(id, pdfViewer);
@@ -19,9 +14,15 @@ export async function init(id, invoke, options) {
 
 export function loadPdf(id, url) {
     const pdfViewer = Data.get(id);
-    const { el } = pdfViewer;
+    const { el, invoke, options } = pdfViewer;
+
+    if (!navigator.pdfViewerEnabled) {
+        await invoke.invokeMethodAsync(options.notSupportCallback);
+        return;
+    }
+
     if (url) {
-        const { frame, invoke, options } = pdfViewer;
+        const { frame } = pdfViewer;
         const viewer = frame || createFrame(el);
         if (options.loadedCallaback) {
             viewer.onload = () => {

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
@@ -9,10 +9,10 @@ export async function init(id, invoke, options) {
     Data.set(id, pdfViewer);
 
     const url = el.getAttribute('data-bb-url');
-    loadPdf(id, url);
+    await loadPdf(id, url);
 }
 
-export function loadPdf(id, url) {
+export async function loadPdf(id, url) {
     const pdfViewer = Data.get(id);
     const { el, invoke, options } = pdfViewer;
 


### PR DESCRIPTION
## Link issues
fixes #451 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add OnLoaded and NotSupportCallback parameters to PdfViewer component and wire JS interop to trigger these callbacks on document load and unsupported viewer scenarios

New Features:
- Expose OnLoaded parameter to invoke a .NET callback when the PDF document has loaded
- Expose NotSupportCallback parameter to invoke a .NET callback when the browser’s PDF viewer isn’t supported