### PR TITLE
feat(PdfViewer): add UseGoogleDocs parameter

### DIFF
--- a/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
+++ b/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor
@@ -2,4 +2,4 @@
 @inherits BootstrapModuleComponentBase
 @attribute [JSModuleAutoLoader("./_content/BootstrapBlazor.PdfViewer/PdfViewer.razor.js", JSObjectReference = true, AutoInvokeDispose = false)]
 
-<div @attributes="AdditionalAttributes" id="@Id" data-bb-url="@Url" class="@ClassString" style="@StyleString"></div>
+<div @attributes="AdditionalAttributes" id="@Id" data-bb-google-docs="@UseGoogleDocsString" class="@ClassString" style="@StyleString"></div>

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
@@ -35,6 +35,12 @@ public partial class PdfViewer
     [Parameter]
     public Func<Task>? NotSupportCallback { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether to use Google Docs for PDF rendering. Default is false.
+    /// </summary>
+    [Parameter]
+    public bool UseGoogleDocs { get; set; } = false;
+
     private string? ClassString => CssBuilder.Default("bb-pdf-viewer-container")
         .AddClassFromAttributes(AdditionalAttributes)
         .Build();
@@ -44,6 +50,9 @@ public partial class PdfViewer
         .Build();
 
     private string? _url;
+    private bool _useGoogleDocs;
+
+    private string? UseGoogleDocsString => UseGoogleDocs ? "true" : null;
 
     /// <summary>
     /// <inheritdoc/>
@@ -57,11 +66,25 @@ public partial class PdfViewer
         if (firstRender)
         {
             _url = Url;
+            _useGoogleDocs = UseGoogleDocs;
+            return;
         }
 
+        var rerender = false;
         if (_url != Url)
         {
             _url = Url;
+            rerender = true;
+        }
+
+        if (_useGoogleDocs != UseGoogleDocs)
+        {
+            _useGoogleDocs = UseGoogleDocs;
+            rerender = true;
+        }
+
+        if (rerender)
+        {
             await InvokeVoidAsync("loadPdf", Id, _url);
         }
     }
@@ -73,7 +96,8 @@ public partial class PdfViewer
     protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, new
     {
         LoadedCallaback = nameof(TriggerOnLoaded),
-        NotSupportCallback = nameof(TriggerNotSupportCallback)
+        NotSupportCallback = nameof(TriggerNotSupportCallback),
+        Url
     });
 
     /// <summary>

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.js
@@ -8,8 +8,7 @@ export async function init(id, invoke, options) {
     const pdfViewer = { el, invoke, options };
     Data.set(id, pdfViewer);
 
-    const url = el.getAttribute('data-bb-url');
-    await loadPdf(id, url);
+    await loadPdf(id, options.url);
 }
 
 export async function loadPdf(id, url) {
@@ -21,6 +20,9 @@ export async function loadPdf(id, url) {
         return;
     }
 
+    delete pdfViewer.frame;
+    el.innerHTML = '';
+
     if (url) {
         const { frame } = pdfViewer;
         const viewer = frame || createFrame(el);
@@ -29,11 +31,12 @@ export async function loadPdf(id, url) {
                 invoke.invokeMethodAsync(options.loadedCallaback);
             };
         }
+
+        const useGoogleDocs = el.getAttribute('data-bb-google-docs') === 'true';
+        if (useGoogleDocs) {
+            url = `http://docs.google.com/viewer?url=${url}`
+        }
         viewer.src = url;
-    }
-    else {
-        delete pdfViewer.frame;
-        el.innerHTML = '';
     }
 }
 


### PR DESCRIPTION
## Link issues
fixes #453 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Introduce a new UseGoogleDocs parameter and update the interop logic to load PDFs via Google Docs when enabled, while ensuring the viewer is properly reinitialized on configuration changes.

New Features:
- Add UseGoogleDocs parameter to PdfViewer to enable rendering PDFs through the Google Docs viewer.

Enhancements:
- Reload the PDF viewer when the UseGoogleDocs flag or URL changes to reflect updated settings.