### PR TITLE
feat(DockView): add overflow style for floating window

### DIFF
--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -276,3 +276,7 @@
 .bb-dockview .dv-tab.dv-inactive-tab .dv-default-tab .dv-default-tab-action {
     visibility: visible;
 }
+
+.bb-dockview .bb-overflowHidden {
+    overflow: hidden;
+}

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview.css
@@ -1023,67 +1023,6 @@
   pointer-events: none;
   background-color: var(--dv-separator-border);
 }
-.dv-dragged {
-  transform: translate3d(0px, 0px, 0px); /* forces tab to be drawn on a separate layer (see https://github.com/microsoft/vscode/issues/18733) */
-}
-
-.dv-tab {
-  flex-shrink: 0;
-}
-.dv-tab:focus-within, .dv-tab:focus {
-  position: relative;
-}
-.dv-tab:focus-within::after, .dv-tab:focus::after {
-  position: absolute;
-  content: "";
-  height: 100%;
-  width: 100%;
-  top: 0px;
-  left: 0px;
-  pointer-events: none;
-  outline: 1px solid var(--dv-tab-divider-color) !important;
-  outline-offset: -1px;
-  z-index: 5;
-}
-.dv-tab.dv-tab-dragging .dv-default-tab-action {
-  background-color: var(--dv-activegroup-visiblepanel-tab-color);
-}
-.dv-tab.dv-active-tab .dv-default-tab .dv-default-tab-action {
-  visibility: visible;
-}
-.dv-tab.dv-inactive-tab .dv-default-tab .dv-default-tab-action {
-  visibility: hidden;
-}
-.dv-tab.dv-inactive-tab .dv-default-tab:hover .dv-default-tab-action {
-  visibility: visible;
-}
-.dv-tab .dv-default-tab {
-  position: relative;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-.dv-tab .dv-default-tab .dv-default-tab-content {
-  flex-grow: 1;
-  margin-right: 4px;
-}
-.dv-tab .dv-default-tab .dv-default-tab-action {
-  padding: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-}
-.dv-tab .dv-default-tab .dv-default-tab-action:hover {
-  border-radius: 2px;
-  background-color: var(--dv-icon-hover-background-color);
-}
-.dv-watermark {
-  display: flex;
-  height: 100%;
-}
 .dv-tabs-overflow-dropdown-default {
   height: 100%;
   color: var(--dv-activegroup-hiddenpanel-tab-color);
@@ -1189,4 +1128,65 @@
 }
 .dv-tabs-and-actions-container .dv-right-actions-container {
   display: flex;
+}
+.dv-dragged {
+  transform: translate3d(0px, 0px, 0px); /* forces tab to be drawn on a separate layer (see https://github.com/microsoft/vscode/issues/18733) */
+}
+
+.dv-tab {
+  flex-shrink: 0;
+}
+.dv-tab:focus-within, .dv-tab:focus {
+  position: relative;
+}
+.dv-tab:focus-within::after, .dv-tab:focus::after {
+  position: absolute;
+  content: "";
+  height: 100%;
+  width: 100%;
+  top: 0px;
+  left: 0px;
+  pointer-events: none;
+  outline: 1px solid var(--dv-tab-divider-color) !important;
+  outline-offset: -1px;
+  z-index: 5;
+}
+.dv-tab.dv-tab-dragging .dv-default-tab-action {
+  background-color: var(--dv-activegroup-visiblepanel-tab-color);
+}
+.dv-tab.dv-active-tab .dv-default-tab .dv-default-tab-action {
+  visibility: visible;
+}
+.dv-tab.dv-inactive-tab .dv-default-tab .dv-default-tab-action {
+  visibility: hidden;
+}
+.dv-tab.dv-inactive-tab .dv-default-tab:hover .dv-default-tab-action {
+  visibility: visible;
+}
+.dv-tab .dv-default-tab {
+  position: relative;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.dv-tab .dv-default-tab .dv-default-tab-content {
+  flex-grow: 1;
+  margin-right: 4px;
+}
+.dv-tab .dv-default-tab .dv-default-tab-action {
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+.dv-tab .dv-default-tab .dv-default-tab-action:hover {
+  border-radius: 2px;
+  background-color: var(--dv-icon-hover-background-color);
+}
+.dv-watermark {
+  display: flex;
+  height: 100%;
 }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -172,6 +172,9 @@ const createGroupActions = (group, groupType) => {
     setTimeout(() => {
         groupType = groupType || group.getParams()?.floatType
         resetActionStates(group, actionContainer, groupType);
+        if (showUp(group) && getUpState(group)) {
+            group.panels.forEach(panel => panel.view.content.element.classList.add('bb-overflowHidden'))
+        }
     }, 0)
     addActionEvent(group, actionContainer);
 }
@@ -618,6 +621,7 @@ const down = (group, actionContainer) => {
             parentEle.style.bottom = parseFloat(bottom) - (packup.height - tabHeight) + 'px'
         }
         actionContainer.classList.add('bb-up');
+        group.panels.forEach(panel => panel.view.content.element.classList.remove('bb-overflowHidden'))
     }
     else {
         group.setParams({ packup: { isPackup: true, height: parseFloat(height) } });
@@ -626,6 +630,7 @@ const down = (group, actionContainer) => {
             parentEle.style.bottom = parseFloat(bottom) + (parseFloat(height) - tabHeight) + 'px'
         }
         actionContainer.classList.remove('bb-up')
+        group.panels.forEach(panel => panel.view.content.element.classList.add('bb-overflowHidden'))
     }
     saveConfig(group.api.accessor)
 }


### PR DESCRIPTION
## Link issues
fixes #472 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Upgrade Dockview to v4.3.1 with upstream bug fixes, event enhancements, popup improvements, and CSS cleanups

New Features:
- Enable replay of the last event for onDidActivePanelChange via the Emitter replay option

Bug Fixes:
- Correct DropTarget option typos by renaming overrideTraget to overrideTarget and dropTraget to dropTarget

Enhancements:
- Support explicit referenceGroup parameter when creating popout overlays and adjust addPopoutGroup signature accordingly
- Toggle overflowHidden CSS class on panel content during group packup and unpack to manage overflow

Chores:
- Bump dockview-core version from 4.2.5 to 4.3.1
- Consolidate duplicated tab CSS rules into dockview.css and add .bb-overflowHidden class in dockview-bb.css