### PR TITLE
feat(DockView): add float window shadow style

### DIFF
--- a/src/components/BootstrapBlazor.CherryMarkdown/BootstrapBlazor.CherryMarkdown.csproj
+++ b/src/components/BootstrapBlazor.CherryMarkdown/BootstrapBlazor.CherryMarkdown.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.1</Version>
+    <Version>9.0.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.1.16</Version>
+    <Version>9.1.17</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -27,10 +27,6 @@
         --dv-tabs-and-actions-container-font-size: 12px;
     }
 
-    .bb-dockview .dv-resize-container {
-        border: 1px solid var(--bs-border-color);
-    }
-
     .bb-dockview .bb-dockview-panel {
         height: 100%;
         width: 100%;

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -27,6 +27,16 @@
         --dv-tabs-and-actions-container-font-size: 12px;
     }
 
+    .bb-dockview .dockview-theme-light {
+        --dv-floating-box-shadow: 0px 0px 0px 1px var(--bs-border-color), 0px 6px 12px -3px #25292e0a, 0px 6px 18px 0px #25292e1f;
+    }
+
+    .bb-dockview .dv-resize-container {
+        border: none;
+        border-radius: var(--bs-border-radius);
+        overflow: hidden;
+    }
+
     .bb-dockview .bb-dockview-panel {
         height: 100%;
         width: 100%;


### PR DESCRIPTION
## Link issues
fixes #487 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add shadow styling for floating windows in the DockView light theme and refine the resize container appearance by removing its border and adding rounded corners with overflow hidden.

New Features:
- Add floating window shadow style to DockView light theme

Enhancements:
- Remove border from resize container and apply border radius with overflow hidden