### PR TITLE
feat(Html2Pdf): add support to ARM browsers

### DIFF
--- a/src/components/BootstrapBlazor.Html2Pdf/BootstrapBlazor.Html2Pdf.csproj
+++ b/src/components/BootstrapBlazor.Html2Pdf/BootstrapBlazor.Html2Pdf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.2</Version>
+    <Version>9.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Link issues
fixes #491 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enable ARM browser support and improve observability for HTML-to-PDF service by injecting logging, proxy configuration, and robust error handling.

Enhancements:
- Inject ILogger into DefaultPdfService and expose a WebProxy property to configure network proxy for PuppeteerSharp’s BrowserFetcher.
- Wrap all PDF generation methods in try-catch blocks with error logging for clearer diagnostics.
- Refactor LaunchBrowserAsync to use the instance-level WebProxy, log download and launch progress, and unify logging through a private helper method.