### PR TITLE
feat(PdfViewer): add PageIndex parameter

### DIFF
--- a/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
+++ b/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.3</Version>
+    <Version>9.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
+++ b/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.4</Version>
+    <Version>9.0.5</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
@@ -58,9 +58,6 @@ public partial class PdfViewer
         .AddClass($"--bb-pdf-viewer-height: {Height};", !string.IsNullOrEmpty(Height))
         .Build();
 
-    private string? _url;
-    private bool _useGoogleDocs;
-
     private string? UseGoogleDocsString => UseGoogleDocs ? "true" : null;
 
     /// <summary>
@@ -72,29 +69,9 @@ public partial class PdfViewer
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (firstRender)
+        if (!firstRender)
         {
-            _url = Url;
-            _useGoogleDocs = UseGoogleDocs;
-            return;
-        }
-
-        var rerender = false;
-        if (_url != Url)
-        {
-            _url = Url;
-            rerender = true;
-        }
-
-        if (_useGoogleDocs != UseGoogleDocs)
-        {
-            _useGoogleDocs = UseGoogleDocs;
-            rerender = true;
-        }
-
-        if (rerender)
-        {
-            await InvokeVoidAsync("loadPdf", Id, GetAbsoluteUri(_url));
+            await InvokeVoidAsync("loadPdf", Id, GetAbsoluteUri(Url));
         }
     }
 

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
@@ -18,6 +18,12 @@ public partial class PdfViewer
     public string? Url { get; set; }
 
     /// <summary>
+    /// Gets or sets the page index of the PDF file.
+    /// </summary>
+    [Parameter]
+    public int PageIndex { get; set; }
+
+    /// <summary>
     /// Gets or sets the viewer height. Default is null.
     /// </summary>
     [Parameter]
@@ -108,7 +114,7 @@ public partial class PdfViewer
         url ??= string.Empty;
         if (string.IsNullOrEmpty(url) || !UseGoogleDocs)
         {
-            return url;
+            return $"{url}#page={PageIndex}";
         }
         var uri = NavigationManager.ToAbsoluteUri(url);
         return uri.AbsoluteUri;


### PR DESCRIPTION
## Link issues
fixes #505 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Introduce a new PageIndex parameter, update URL generation to include the page anchor, and simplify reload logic by removing redundant state fields in PdfViewer.

New Features:
- Add PageIndex parameter to PdfViewer component to allow specifying the initial page index of the PDF.

Enhancements:
- Streamline OnAfterRenderAsync by removing URL and UseGoogleDocs state tracking and always invoking loadPdf on updates.