### PR TITLE
fix(PdfViewer): do not render when url is empty

### DIFF
--- a/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
+++ b/src/components/BootstrapBlazor.PdfViewer/BootstrapBlazor.PdfViewer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.5</Version>
+    <Version>9.0.6</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
+++ b/src/components/BootstrapBlazor.PdfViewer/PdfViewer.razor.cs
@@ -88,13 +88,13 @@ public partial class PdfViewer
 
     private string GetAbsoluteUri(string? url)
     {
-        url ??= string.Empty;
-        if (string.IsNullOrEmpty(url) || !UseGoogleDocs)
+        if (string.IsNullOrEmpty(url))
         {
-            return $"{url}#page={PageIndex}";
+            return string.Empty;
         }
+
         var uri = NavigationManager.ToAbsoluteUri(url);
-        return uri.AbsoluteUri;
+        return $"{uri.AbsoluteUri}#page={PageIndex}";
     }
 
     /// <summary>


### PR DESCRIPTION
## Link issues
fixes #507 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Prevent the PdfViewer from rendering an invalid URL by returning an empty string for empty inputs and consistently appending the page index to the absolute URI.

Bug Fixes:
- Return an empty string from GetAbsoluteUri when the URL is empty instead of rendering a broken link
- Always append the page index to the resolved absolute URI and remove the UseGoogleDocs check