### PR TITLE
feat(TcpSocket): remove SetDataPackageAdapter method

### DIFF
--- a/src/extensions/BootstrapBlazor.Socket/BootstrapBlazor.Socket.csproj
+++ b/src/extensions/BootstrapBlazor.Socket/BootstrapBlazor.Socket.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>9.0.3</Version>
+    <Version>9.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/extensions/BootstrapBlazor.Socket/DataConverter/DataConverter.cs
+++ b/src/extensions/BootstrapBlazor.Socket/DataConverter/DataConverter.cs
@@ -38,9 +38,7 @@ public class DataConverter<TEntity>(DataConverterCollections converters) : IData
                 ret = true;
             }
         }
-        catch (Exception e)
-        {
-        }
+        catch { }
 
         return ret;
     }

--- a/src/extensions/BootstrapBlazor.Socket/DataConverter/DataConverter.cs
+++ b/src/extensions/BootstrapBlazor.Socket/DataConverter/DataConverter.cs
@@ -17,7 +17,6 @@ public class DataConverter<TEntity>(DataConverterCollections converters) : IData
     /// </summary>
     public DataConverter() : this(new())
     {
-
     }
 
     /// <summary>
@@ -28,9 +27,21 @@ public class DataConverter<TEntity>(DataConverterCollections converters) : IData
     /// <returns></returns>
     public virtual bool TryConvertTo(ReadOnlyMemory<byte> data, [NotNullWhen(true)] out TEntity? entity)
     {
-        var v = CreateEntity();
-        var ret = Parse(data, v);
-        entity = ret ? v : default;
+        var ret = false;
+        entity = default;
+        try
+        {
+            var v = CreateEntity();
+            if (Parse(data, v))
+            {
+                entity = v;
+                ret = true;
+            }
+        }
+        catch (Exception e)
+        {
+        }
+
         return ret;
     }
 
@@ -57,8 +68,7 @@ public class DataConverter<TEntity>(DataConverterCollections converters) : IData
             var properties = entity.GetType().GetProperties().Where(p => p.CanWrite).ToList();
             foreach (var p in properties)
             {
-                var attr = p.GetCustomAttribute<DataPropertyConverterAttribute>(false)
-                    ?? GetPropertyConverterAttribute(p);
+                var attr = p.GetCustomAttribute<DataPropertyConverterAttribute>(false) ?? GetPropertyConverterAttribute(p);
                 if (attr is { Type: not null })
                 {
                     var value = attr.ConvertTo(data);
@@ -69,8 +79,10 @@ public class DataConverter<TEntity>(DataConverterCollections converters) : IData
                     }
                 }
             }
+
             ret = true;
         }
+
         return ret;
     }
 
@@ -81,6 +93,7 @@ public class DataConverter<TEntity>(DataConverterCollections converters) : IData
         {
             attr = v;
         }
+
         return attr;
     }
 }

--- a/src/extensions/BootstrapBlazor.TcpSocket/BootstrapBlazor.TcpSocket.csproj
+++ b/src/extensions/BootstrapBlazor.TcpSocket/BootstrapBlazor.TcpSocket.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>9.0.2</Version>
+    <Version>9.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/extensions/BootstrapBlazor.TcpSocket/BootstrapBlazor.TcpSocket.csproj
+++ b/src/extensions/BootstrapBlazor.TcpSocket/BootstrapBlazor.TcpSocket.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>9.0.3</Version>
+    <Version>9.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/extensions/BootstrapBlazor.TcpSocket/Extensions/ITcpSocketClientExtensions.cs
+++ b/src/extensions/BootstrapBlazor.TcpSocket/Extensions/ITcpSocketClientExtensions.cs
@@ -20,7 +20,7 @@ public static class ITcpSocketClientExtensions
     /// Sends the specified string content to the connected TCP socket client asynchronously.
     /// </summary>
     /// <remarks>This method converts the provided string content into a byte array using the specified
-    /// encoding  (or UTF-8 by default) and sends it to the connected TCP socket client. Ensure the client is connected 
+    /// encoding  (or UTF-8 by default) and sends it to the connected TCP socket client. Ensure the client is connected
     /// before calling this method.</remarks>
     /// <param name="client">The TCP socket client to which the content will be sent. Cannot be <see langword="null"/>.</param>
     /// <param name="content">The string content to send. Cannot be <see langword="null"/> or empty.</param>
@@ -51,7 +51,7 @@ public static class ITcpSocketClientExtensions
         return client.ConnectAsync(endPoint, token);
     }
 
-    private static readonly Dictionary<ITcpSocketClient, List<(IDataPackageAdapter Adapter, Func<ReadOnlyMemory<byte>, ValueTask> Callback)>> _cache = [];
+    private static readonly Dictionary<ITcpSocketClient, List<(IDataPackageAdapter Adapter, Func<ReadOnlyMemory<byte>, ValueTask> Callback)>> Cache = [];
 
     /// <summary>
     /// 增加 <see cref="ITcpSocketClient"/> 数据适配器及其对应的回调方法
@@ -67,13 +67,13 @@ public static class ITcpSocketClientExtensions
             await adapter.HandlerAsync(buffer);
         }
 
-        if (_cache.TryGetValue(client, out var list))
+        if (Cache.TryGetValue(client, out var list))
         {
             list.Add((adapter, cb));
         }
         else
         {
-            _cache.Add(client, [(adapter, cb)]);
+            Cache.Add(client, [(adapter, cb)]);
         }
 
         client.ReceivedCallBack += cb;
@@ -89,7 +89,7 @@ public static class ITcpSocketClientExtensions
     /// <param name="callback"></param>
     public static void RemoveDataPackageAdapter(this ITcpSocketClient client, Func<ReadOnlyMemory<byte>, ValueTask> callback)
     {
-        if (_cache.TryGetValue(client, out var list))
+        if (Cache.TryGetValue(client, out var list))
         {
             var items = list.Where(i => i.Adapter.ReceivedCallBack == callback).ToList();
             foreach (var c in items)
@@ -131,13 +131,13 @@ public static class ITcpSocketClientExtensions
             await adapter.HandlerAsync(buffer);
         }
 
-        if (_cache.TryGetValue(client, out var list))
+        if (Cache.TryGetValue(client, out var list))
         {
             list.Add((adapter, cb));
         }
         else
         {
-            _cache.Add(client, [(adapter, cb)]);
+            Cache.Add(client, [(adapter, cb)]);
         }
 
         client.ReceivedCallBack += cb;
@@ -188,13 +188,13 @@ public static class ITcpSocketClientExtensions
             await adapter.HandlerAsync(buffer);
         }
 
-        if (_cache.TryGetValue(client, out var list))
+        if (Cache.TryGetValue(client, out var list))
         {
             list.Add((adapter, cb));
         }
         else
         {
-            _cache.Add(client, [(adapter, cb)]);
+            Cache.Add(client, [(adapter, cb)]);
         }
 
         IDataConverter<TEntity>? converter = null;

--- a/src/extensions/BootstrapBlazor.TcpSocket/Extensions/ITcpSocketClientExtensions.cs
+++ b/src/extensions/BootstrapBlazor.TcpSocket/Extensions/ITcpSocketClientExtensions.cs
@@ -101,7 +101,7 @@ public static class ITcpSocketClientExtensions
     }
 
     /// <summary>
-    /// 通过指定 <see cref="IDataPackageHandler"/> 数据处理实例，设置数据适配器并配置回调方法
+    /// 通过指定 <see cref="IDataPackageHandler"/> 数据处理实例，设置数据适配器并配置回调方法，切记使用 <see cref="RemoveDataPackageAdapter(ITcpSocketClient, Func{ReadOnlyMemory{byte}, ValueTask})"/> 移除数据处理委托防止内存泄露
     /// </summary>
     /// <param name="client"><see cref="ITcpSocketClient"/> 实例</param>
     /// <param name="handler"><see cref="IDataPackageHandler"/> 数据处理实例</param>
@@ -115,7 +115,7 @@ public static class ITcpSocketClientExtensions
 
     /// <summary>
     /// Configures the specified <see cref="ITcpSocketClient"/> to use a data package adapter and a callback function
-    /// for processing received data.
+    /// for processing received data. 切记使用 <see cref="RemoveDataPackageAdapter(ITcpSocketClient, Func{ReadOnlyMemory{byte}, ValueTask})"/> 移除数据处理委托防止内存泄露
     /// </summary>
     /// <remarks>This method sets up the <paramref name="client"/> to process incoming data using the
     /// specified <paramref name="adapter"/> and  <paramref name="socketDataConverter"/>. The <paramref
@@ -175,7 +175,7 @@ public static class ITcpSocketClientExtensions
     }
 
     /// <summary>
-    /// 通过指定 <see cref="IDataPackageHandler"/> 数据处理实例，设置数据适配器并配置回调方法
+    /// 通过指定 <see cref="IDataPackageHandler"/> 数据处理实例，设置数据适配器并配置回调方法。切记使用 <see cref="RemoveDataPackageAdapter"/> 移除数据处理委托防止内存泄露
     /// </summary>
     /// <typeparam name="TEntity"></typeparam>
     /// <param name="client"></param>
@@ -189,7 +189,7 @@ public static class ITcpSocketClientExtensions
 
     /// <summary>
     /// Configures the specified <see cref="ITcpSocketClient"/> to use a custom data package adapter and callback
-    /// function.
+    /// function. 切记使用 <see cref="RemoveDataPackageAdapter"/> 移除数据处理委托防止内存泄露
     /// </summary>
     /// <remarks>This method sets up the <paramref name="client"/> to use the specified <paramref
     /// name="adapter"/> for handling incoming data. If the <typeparamref name="TEntity"/> type is decorated with a <see
@@ -251,7 +251,7 @@ public static class ITcpSocketClientExtensions
     }
 
     /// <summary>
-    /// 通过指定 <see cref="IDataPackageHandler"/> 数据处理实例，设置数据适配器并配置回调方法
+    /// 通过指定 <see cref="IDataPackageHandler"/> 数据处理实例，设置数据适配器并配置回调方法。切记使用 <see cref="RemoveDataPackageAdapter"/> 移除数据处理委托防止内存泄露
     /// </summary>
     /// <param name="client"><see cref="ITcpSocketClient"/> 实例</param>
     /// <param name="handler"><see cref="IDataPackageHandler"/> 数据处理实例</param>

--- a/test/UnitTestTcpSocket/TcpSocketFactoryTest.cs
+++ b/test/UnitTestTcpSocket/TcpSocketFactoryTest.cs
@@ -642,12 +642,13 @@ public class TcpSocketFactoryTest
 
         // 设置数据适配器
         var adapter = new DataPackageAdapter(new FixLengthDataPackageHandler(29));
-        client.AddDataPackageAdapter(adapter, new DataConverter<MockEntity>(), t =>
+        var callback = new Func<MockEntity?, Task>(t =>
         {
             entity = t;
             tcs.SetResult();
             return Task.CompletedTask;
         });
+        client.AddDataPackageAdapter(adapter, new DataConverter<MockEntity>(), callback);
 
         // 连接 TCP Server
         var connect = await client.ConnectAsync("localhost", port);
@@ -704,6 +705,7 @@ public class TcpSocketFactoryTest
 
         // no attribute
         Assert.Null(entity.Value13);
+        client.RemoveDataPackageAdapter(callback);
 
         // 测试 SocketDataConverter 标签功能
         tcs = new TaskCompletionSource();

--- a/test/UnitTestTcpSocket/TcpSocketFactoryTest.cs
+++ b/test/UnitTestTcpSocket/TcpSocketFactoryTest.cs
@@ -497,7 +497,7 @@ public class TcpSocketFactoryTest
 
         // 设置数据适配器
         var adapter = new DataPackageAdapter(new FixLengthDataPackageHandler(7));
-        client.SetDataPackageAdapter(adapter, buffer =>
+        var callback = new Func<ReadOnlyMemory<byte>, ValueTask>(buffer =>
         {
             // buffer 即是接收到的数据
             buffer.CopyTo(receivedBuffer);
@@ -505,6 +505,7 @@ public class TcpSocketFactoryTest
             tcs.SetResult();
             return ValueTask.CompletedTask;
         });
+        client.AddDataPackageAdapter(adapter, callback);
 
         // 测试 ConnectAsync 方法
         var connect = await client.ConnectAsync("localhost", port);
@@ -538,7 +539,7 @@ public class TcpSocketFactoryTest
 
         // 设置数据适配器
         var adapter = new DataPackageAdapter(new FixLengthDataPackageHandler(7));
-        client.SetDataPackageAdapter(adapter, buffer =>
+        client.AddDataPackageAdapter(adapter, buffer =>
         {
             // buffer 即是接收到的数据
             buffer.CopyTo(receivedBuffer);
@@ -588,7 +589,7 @@ public class TcpSocketFactoryTest
 
         // 设置数据适配器
         var adapter = new DataPackageAdapter(new DelimiterDataPackageHandler([13, 10]));
-        client.SetDataPackageAdapter(adapter, buffer =>
+        client.AddDataPackageAdapter(adapter, buffer =>
         {
             // buffer 即是接收到的数据
             buffer.CopyTo(receivedBuffer);
@@ -641,7 +642,7 @@ public class TcpSocketFactoryTest
 
         // 设置数据适配器
         var adapter = new DataPackageAdapter(new FixLengthDataPackageHandler(29));
-        client.SetDataPackageAdapter(adapter, new DataConverter<MockEntity>(), t =>
+        client.AddDataPackageAdapter(adapter, new DataConverter<MockEntity>(), t =>
         {
             entity = t;
             tcs.SetResult();
@@ -706,7 +707,7 @@ public class TcpSocketFactoryTest
 
         // 测试 SocketDataConverter 标签功能
         tcs = new TaskCompletionSource();
-        client.SetDataPackageAdapter<MockEntity>(adapter, t =>
+        client.AddDataPackageAdapter<MockEntity>(adapter, t =>
         {
             entity = t;
             tcs.SetResult();
@@ -728,7 +729,7 @@ public class TcpSocketFactoryTest
         // 测试 SetDataPackageAdapter 泛型无标签情况
         tcs = new TaskCompletionSource();
         NoConvertEntity? noConvertEntity = null;
-        client.SetDataPackageAdapter<NoConvertEntity>(adapter, t =>
+        client.AddDataPackageAdapter<NoConvertEntity>(adapter, t =>
         {
             noConvertEntity = t;
             tcs.SetResult();
@@ -779,7 +780,7 @@ public class TcpSocketFactoryTest
         var adapter = new DataPackageAdapter(new FixLengthDataPackageHandler(7));
 
         OptionConvertEntity? entity = null;
-        client.SetDataPackageAdapter<OptionConvertEntity>(adapter, data =>
+        client.AddDataPackageAdapter<OptionConvertEntity>(adapter, data =>
         {
             // buffer 即是接收到的数据
             entity = data;
@@ -857,7 +858,7 @@ public class TcpSocketFactoryTest
         var connect = await client.ConnectAsync("localhost", port);
 
         client.AddDataPackageAdapter(new DataPackageAdapter(new FixLengthDataPackageHandler(7)), ReceivedCallBack);
-        client.SetDataPackageAdapter(new FixLengthDataPackageHandler(7), ReceivedCallBack);
+        client.AddDataPackageAdapter(new FixLengthDataPackageHandler(7), ReceivedCallBack);
 
         var data = new ReadOnlyMemory<byte>([1, 2, 3, 4, 5]);
         await client.SendAsync(data);
@@ -889,10 +890,10 @@ public class TcpSocketFactoryTest
         var connect = await client.ConnectAsync("localhost", port);
 
         client.AddDataPackageAdapter(new DataPackageAdapter(new FixLengthDataPackageHandler(7)), ReceivedCallBack);
-        client.SetDataPackageAdapter<MockEntity>(new FixLengthDataPackageHandler(7), ReceivedEntityCallBack);
+        client.AddDataPackageAdapter<MockEntity>(new FixLengthDataPackageHandler(7), ReceivedEntityCallBack);
 
         client.AddDataPackageAdapter(new DataPackageAdapter(new FixLengthDataPackageHandler(7)), ReceivedCallBack);
-        client.SetDataPackageAdapter(new FixLengthDataPackageHandler(7), new MockSocketDataConverter(), ReceivedEntityCallBack);
+        client.AddDataPackageAdapter(new FixLengthDataPackageHandler(7), new MockSocketDataConverter(), ReceivedEntityCallBack);
 
         var data = new ReadOnlyMemory<byte>([1, 2, 3, 4, 5]);
         await client.SendAsync(data);
@@ -930,7 +931,7 @@ public class TcpSocketFactoryTest
         // 连接 TCP Server
         var connect = await client.ConnectAsync("localhost", port);
 
-        client.SetDataPackageAdapter<MockConverterEntity>(new FixLengthDataPackageHandler(7), ReceivedCallBack);
+        client.AddDataPackageAdapter<MockConverterEntity>(new FixLengthDataPackageHandler(7), ReceivedCallBack);
 
         var data = new ReadOnlyMemory<byte>([1, 2, 3, 4, 5]);
         await client.SendAsync(data);


### PR DESCRIPTION
## Link issues
fixes #549 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Remove SetDataPackageAdapter methods in favor of AddDataPackageAdapter overloads, add support for multiple adapters and generic callbacks via caching, and improve data conversion error handling

New Features:
- Introduce unified AddDataPackageAdapter extension methods and remove all SetDataPackageAdapter overloads
- Support registering multiple data package adapters and generic entity callbacks via a new EntityCache

Enhancements:
- Rename internal adapter cache from `_cache` to `Cache` and restructure callback registration with local delegates
- Enhance DataConverter.TryConvertTo to catch exceptions and safely return default on parse errors

Tests:
- Update unit tests to replace SetDataPackageAdapter calls with the new AddDataPackageAdapter methods