### PR TITLE
chore(BaiduSpeech): bump Newtonsoft.Json version to latest

### DIFF
--- a/src/components/BootstrapBlazor.BaiduSpeech/BootstrapBlazor.BaiduSpeech.csproj
+++ b/src/components/BootstrapBlazor.BaiduSpeech/BootstrapBlazor.BaiduSpeech.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Baidu.AI" Version="4.15.16" />
     <PackageReference Include="BootstrapBlazor" Version="$(BBVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Link issues
fixes #678 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Upgrade Newtonsoft.Json dependency in BaiduSpeech component to the latest version, resolving issue #678.

Bug Fixes:
- Fix #678 by updating the Newtonsoft.Json package version

Build:
- Bump Newtonsoft.Json package reference to the latest version in BaiduSpeech project