### PR TITLE
feat(PdfReader): getFileSize support stream

### DIFF
--- a/src/components/BootstrapBlazor.PdfReader/PdfReader.razor.js
+++ b/src/components/BootstrapBlazor.PdfReader/PdfReader.razor.js
@@ -211,7 +211,7 @@ const loadMetadata = (el, pdfViewer, metadata) => {
     }
 
     const filesize = el.querySelector('.bb-view-pdf-dialog-file-size');
-    filesize.textContent = getFilesize(metadata);
+    filesize.textContent = getFileSize(metadata);
 
     const title = el.querySelector('.bb-view-pdf-dialog-title');
     const author = el.querySelector('.bb-view-pdf-dialog-author');
@@ -294,7 +294,7 @@ function parsePdfDate(pdfDateString) {
     return date;
 }
 
-const getFilesize = metadata => {
+const getFileSize = metadata => {
     const length = metadata.contentLength;
     let val = 0;
     let unit = 'B';


### PR DESCRIPTION
## Link issues
fixes #842 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Improve PDF reader file size handling and display in the JavaScript viewer.

Bug Fixes:
- Fallback to the PDF data length when metadata contentLength is missing so file size can still be determined, e.g., for streamed sources.

Enhancements:
- Unify and rename the file size helper to getFileSize and standardize file size formatting to rounded values with up to two decimal places.