### PR TITLE
feat(Chart): add RemoveDataset instance method

### DIFF
--- a/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.cs
+++ b/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.cs
@@ -238,7 +238,7 @@ public partial class Chart
     }
 
     /// <summary>
-    /// 删除数据集
+    /// 根据索引删除数据集
     /// </summary>
     /// <param name="index"></param>
     /// <returns></returns>
@@ -256,8 +256,43 @@ public partial class Chart
         if (_ds != null)
         {
             _ds.Data.RemoveAt(index);
+
+            await UpdateDataset(_ds);
         }
-        await InvokeVoidAsync("update", Id, _ds, ChartAction.RemoveDataset.ToDescriptionString());
+    }
+
+    /// <summary>
+    /// 根据标签名称删除数据集
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="comparison"></param>
+    /// <returns></returns>
+    public async Task RemoveDataset(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+    {
+        if (_ds == null)
+        {
+            if (OnInitAsync != null)
+            {
+                _ds = await OnInitAsync();
+                UpdateOptions(_ds);
+            }
+        }
+
+        if (_ds != null)
+        {
+            var data = _ds.Data.Find(i => i.Label?.Equals(name, comparison) ?? false);
+            if (data != null)
+            {
+                _ds.Data.Remove(data);
+            }
+
+            await UpdateDataset(_ds);
+        }
+    }
+
+    private async Task UpdateDataset(ChartDataSource dataSource)
+    {
+        await InvokeVoidAsync("update", Id, dataSource, ChartAction.RemoveDataset.ToDescriptionString());
 
         if (OnAfterUpdateAsync != null)
         {


### PR DESCRIPTION
## Link issues
fixes #872 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add support for removing chart datasets both by index and by label, and centralize the dataset update logic when datasets are removed.

New Features:
- Support removing a chart dataset by its label with configurable string comparison.

Enhancements:
- Refine the existing dataset removal method to update the chart via a shared helper after removing an item by index.
- Introduce a shared helper method to update the chart whenever a dataset is removed.