### PR TITLE
fix(DockViewV2): TitleTemplate with ShowClose to false not work

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.6</Version>
+    <Version>10.0.7</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -127,6 +127,7 @@
             }
 
         .bb-dockview .dv-tab-on > .dv-default-tab-content + .dv-default-tab-action,
+        .bb-dockview .dv-tab-on > .bb-dockview-item-title + .dv-default-tab-action,
         .bb-dockview .dv-tabs-and-actions-container:has(.dv-tab-on) > .dv-right-actions-container > .bb-dockview-control-icon-close,
         .bb-dockview .dv-right-actions-container:not(.bb-show-pin) .bb-dockview-control-icon-pin,
         .bb-dockview .dv-right-actions-container:not(.bb-show-pin) .bb-dockview-control-icon-pushpin,

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -1,4 +1,4 @@
-﻿@import './dockview.css';
+@import './dockview.css';
 
 .bb-dockview {
     --bb-dockview-padding: .25rem;


### PR DESCRIPTION
## Link issues
fixes #970 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix close button visibility when using a custom DockView item title template with ShowClose set to false.