### PR TITLE
feat(DockView): add OnlyWhenVisible render mode

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.6</Version>
+    <Version>10.0.7</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.8-beta01</Version>
+    <Version>10.0.8-beta02</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.8-beta04</Version>
+    <Version>10.0.8-beta05</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.8-beta02</Version>
+    <Version>10.0.8-beta03</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.8-beta03</Version>
+    <Version>10.0.8-beta04</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.7</Version>
+    <Version>10.0.8-beta01</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor
@@ -11,7 +11,7 @@
     {
         <DockViewTitleBar BarIcon="@TitleBarIcon" BarIconUrl="@TitleBarIconUrl" OnClickBarCallback="OnClickBar"></DockViewTitleBar>
     }
-    @if (_rendered)
+    @if (IsRender())
     {
         @ChildContent
     }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor
@@ -11,7 +11,7 @@
     {
         <DockViewTitleBar BarIcon="@TitleBarIcon" BarIconUrl="@TitleBarIconUrl" OnClickBarCallback="OnClickBar"></DockViewTitleBar>
     }
-    @if (Visible)
+    @if (_rendered)
     {
         @ChildContent
     }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Argo Zhang (argo@163.com). All rights reserved.
+// Copyright (c) Argo Zhang (argo@163.com). All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 // Website: https://www.blazor.zone or https://argozhang.github.io/
 
@@ -134,6 +134,15 @@ public partial class DockViewComponent
     public Func<Task>? OnClickTitleBarCallback { get; set; }
 
     /// <summary>
+    /// <para lang="zh">获得/设置 DockContent 实例</para>
+    /// <para lang="en">Gets or sets the DockContent instance.</para>
+    /// </summary>
+    [CascadingParameter]
+    [NotNull]
+    [JsonIgnore]
+    private DockViewV2? DockView { get; set; }
+
+    /// <summary>
     /// <inheritdoc/>
     /// </summary>
     protected override void OnInitialized()
@@ -141,6 +150,21 @@ public partial class DockViewComponent
         base.OnInitialized();
 
         Type = DockViewContentType.Component;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        // 根据容器状态同步组件状态
+        if (!string.IsNullOrEmpty(Key) && DockView.ComponentStates.TryGetValue(Key, out var state))
+        {
+            IsLock = state.IsLock;
+            Visible = state.Visible;
+        }
     }
 
     private async Task OnClickBar()

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -162,13 +162,8 @@ public partial class DockViewComponent
 
         Type = DockViewContentType.Component;
 
-        // 增加组件状态
-        DockView?.AddComponentState(new DockViewComponentState(this)
-        {
-            Key = Key,
-            Visible = Visible,
-            IsLock = IsLock
-        });
+        // 增加组件状态用于序列化
+        DockView?.AddComponentState(new DockViewComponentState(this) { Key = Key });
     }
 
     /// <summary>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -171,8 +171,16 @@ public partial class DockViewComponent
                 Visible = Visible,
                 Render = _rendered
             });
-            IsLock = state.IsLock;
-            Visible = state.Visible;
+
+            if (state.Visible != Visible)
+            {
+                state.Visible = Visible;
+            }
+            if (state.IsLock != IsLock)
+            {
+                state.IsLock = IsLock;
+            }
+
             _rendered = state.Render;
         }
     }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -142,6 +142,8 @@ public partial class DockViewComponent
     [JsonIgnore]
     private DockViewV2? DockView { get; set; }
 
+    private bool _rendered = false;
+
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
@@ -164,11 +166,14 @@ public partial class DockViewComponent
         {
             var state = DockView.ComponentStates.GetOrAdd(Key, key => new DockViewComponentState
             {
+                Key = key,
                 IsLock = IsLock,
-                Visible = Visible
+                Visible = Visible,
+                Render = _rendered
             });
             IsLock = state.IsLock;
             Visible = state.Visible;
+            _rendered = state.Render;
         }
     }
 

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -173,6 +173,7 @@ public partial class DockViewComponent
     {
         base.OnParametersSet();
 
+        // 同步组件状态到缓存
         var state = DockView.GetComponentState(Key);
         if (state != null)
         {
@@ -189,9 +190,7 @@ public partial class DockViewComponent
         }
     }
 
-    private bool IsRender() => DockView.GetComponentState(Key).IsRender();
-
-    internal object? GetState() => DockView.GetComponentState(Key).GetComponentState(this);
+    private bool IsRender() => DockView.IsRender(Key);
 
     internal void SetVisible(bool visible) => Visible = visible;
 

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -147,6 +147,7 @@ public partial class DockViewComponent
     /// <para lang="en">Gets or sets the click callback for the leading title icon. Default is null</para>
     /// </summary>
     [Parameter]
+    [JsonIgnore]
     public Func<Task>? OnClickTitleBarCallback { get; set; }
 
     [CascadingParameter]

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -174,12 +174,7 @@ public partial class DockViewComponent
         base.OnParametersSet();
 
         // 同步组件状态到缓存
-        var state = DockView.GetComponentState(Key);
-        if (state != null)
-        {
-            state.Visible = Visible;
-            state.IsLock = IsLock;
-        }
+        DockView.UpdateComponentState(Key, Visible, IsLock);
     }
 
     private async Task OnClickBar()

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -46,7 +46,6 @@ public partial class DockViewComponent
     /// <para lang="en">Gets or sets the title template. Default is null</para>
     /// </summary>
     [Parameter]
-    [JsonIgnore]
     public RenderFragment? TitleTemplate { get; set; }
 
     /// <summary>
@@ -61,7 +60,6 @@ public partial class DockViewComponent
     /// <para lang="en">Gets or sets whether the component is visible. Default is true</para>
     /// </summary>
     [Parameter]
-    [JsonIgnore]
     public bool Visible { get; set; } = true;
 
     /// <summary>
@@ -83,7 +81,6 @@ public partial class DockViewComponent
     /// <para lang="en">Gets or sets whether the component is locked. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
-    [JsonIgnore]
     public bool? IsLock { get; set; }
 
     /// <summary>
@@ -119,7 +116,6 @@ public partial class DockViewComponent
     /// <para lang="en">Gets or sets the component render mode. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Renderer { get; set; }
 
     /// <summary>
@@ -151,16 +147,7 @@ public partial class DockViewComponent
     /// <para lang="en">Gets or sets the click callback for the leading title icon. Default is null</para>
     /// </summary>
     [Parameter]
-    [JsonIgnore]
     public Func<Task>? OnClickTitleBarCallback { get; set; }
-
-    [JsonInclude]
-    [JsonPropertyName("visible")]
-    private bool JsonVisible => DockView.GetComponentState(Key)?.Visible ?? false;
-
-    [JsonInclude]
-    [JsonPropertyName("isLock")]
-    private bool JsonIsLock => DockView.GetComponentState(Key)?.IsLock ?? false;
 
     [CascadingParameter]
     [NotNull]
@@ -194,13 +181,14 @@ public partial class DockViewComponent
 
     private bool IsRender()
     {
-        var render = false;
         var state = DockView.GetComponentState(Key);
-        if (state != null)
-        {
-            render = state.Render && state.Visible;
-        }
-        return render;
+        return state.IsRender();
+    }
+
+    internal object? GetState()
+    {
+        var state = DockView.GetComponentState(Key);
+        return state.GetComponentState(this);
     }
 
     /// <summary>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -8,135 +8,149 @@ using System.Text.Json.Serialization;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// DockContentItem 配置项子项对标 content 配置项内部 content 配置
+/// <para lang="zh">DockView 组件配置项，对应 content 配置项中的组件项</para>
+/// <para lang="en">DockView component option corresponding to a component item in the content configuration</para>
 /// </summary>
 public partial class DockViewComponent
 {
     /// <summary>
-    /// 获得/设置 组件是否显示 Header 默认 true 显示
+    /// <para lang="zh">获得/设置 组件是否显示标题栏，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the component header is displayed. Default is true</para>
     /// </summary>
     [Parameter]
     public bool ShowHeader { get; set; } = true;
 
     /// <summary>
-    /// 获得/设置 组件 Title
+    /// <para lang="zh">获得/设置 组件标题</para>
+    /// <para lang="en">Gets or sets the component title</para>
     /// </summary>
     [Parameter]
     public string? Title { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件 Title 宽度 默认 null 未设置
+    /// <para lang="zh">获得/设置 组件标题宽度，默认为 null</para>
+    /// <para lang="en">Gets or sets the component title width. Default is null</para>
     /// </summary>
     [Parameter]
     public int? TitleWidth { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件 Title 样式 默认 null 未设置
+    /// <para lang="zh">获得/设置 组件标题样式类，默认为 null</para>
+    /// <para lang="en">Gets or sets the component title CSS class. Default is null</para>
     /// </summary>
     [Parameter]
     public string? TitleClass { get; set; }
 
     /// <summary>
-    /// 获得/设置 Title 模板 默认 null 未设置
+    /// <para lang="zh">获得/设置 标题模板，默认为 null</para>
+    /// <para lang="en">Gets or sets the title template. Default is null</para>
     /// </summary>
     [Parameter]
     [JsonIgnore]
     public RenderFragment? TitleTemplate { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件 Class 默认 null 未设置
+    /// <para lang="zh">获得/设置 组件样式类，默认为 null</para>
+    /// <para lang="en">Gets or sets the component CSS class. Default is null</para>
     /// </summary>
     [Parameter]
     public string? Class { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件是否可见 默认 true 可见
+    /// <para lang="zh">获得/设置 组件是否可见，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the component is visible. Default is true</para>
     /// </summary>
     [Parameter]
     public bool Visible { get; set; } = true;
 
     /// <summary>
-    /// 获得/设置 组件是否允许关闭 默认 null 使用 DockView 的配置
+    /// <para lang="zh">获得/设置 组件是否允许关闭，默认为 null，未设置时使用 DockView 的配置</para>
+    /// <para lang="en">Gets or sets whether the component can be closed. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
     public bool? ShowClose { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件唯一标识值 默认 null 未设置时取 Title 作为唯一标识
+    /// <para lang="zh">获得/设置 组件唯一标识，默认为 null，未设置时使用 Title 作为唯一标识</para>
+    /// <para lang="en">Gets or sets the unique component identifier. Default is null. When not set, Title is used as the unique identifier</para>
     /// </summary>
     [Parameter]
     public string? Key { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否锁定 默认 null 未设置时取 DockView 的配置
+    /// <para lang="zh">获得/设置 组件是否锁定，默认为 null，未设置时使用 DockView 的配置</para>
+    /// <para lang="en">Gets or sets whether the component is locked. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
-    /// <remarks>锁定后无法拖动</remarks>
     [Parameter]
     public bool? IsLock { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示锁定按钮 默认 null 未设置时取 DockView 的配置
+    /// <para lang="zh">获得/设置 是否显示锁定按钮，默认为 null，未设置时使用 DockView 的配置</para>
+    /// <para lang="en">Gets or sets whether the lock button is displayed. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
     public bool? ShowLock { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否悬浮 默认 null 未设置时取 DockView 的配置
+    /// <para lang="zh">获得/设置 是否悬浮，默认为 null，未设置时使用 DockView 的配置</para>
+    /// <para lang="en">Gets or sets whether the component is floating. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
     public bool? IsFloating { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示可悬浮按钮 默认 null 未设置时取 DockView 的配置
+    /// <para lang="zh">获得/设置 是否显示悬浮按钮，默认为 null，未设置时使用 DockView 的配置</para>
+    /// <para lang="en">Gets or sets whether the float button is displayed. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
     public bool? ShowFloat { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示最大化按钮 默认 null 未设置时取 DockView 的配置
+    /// <para lang="zh">获得/设置 是否显示最大化按钮，默认为 null，未设置时使用 DockView 的配置</para>
+    /// <para lang="en">Gets or sets whether the maximize button is displayed. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
     public bool? ShowMaximize { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否一直显示 默认 null 未设置时取 DockView 的配置
+    /// <para lang="zh">获得/设置 组件渲染模式，默认为 null，未设置时使用 DockView 的配置</para>
+    /// <para lang="en">Gets or sets the component render mode. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Renderer { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示标题前置图标 默认 false 不显示
+    /// <para lang="zh">获得/设置 是否显示标题前置图标，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the leading title icon is displayed. Default is false</para>
     /// </summary>
     [Parameter]
     [JsonIgnore]
     public bool ShowTitleBar { get; set; }
 
     /// <summary>
-    /// 获得/设置 标题前置图标 默认 null 未设置使用默认图标
+    /// <para lang="zh">获得/设置 标题前置图标，默认为 null，未设置时使用默认图标</para>
+    /// <para lang="en">Gets or sets the leading title icon. Default is null. When not set, the default icon is used</para>
     /// </summary>
     [Parameter]
     [JsonIgnore]
     public string? TitleBarIcon { get; set; }
 
     /// <summary>
-    /// 获得/设置 标题前置图标 Url 默认 null 未设置使用默认图标
+    /// <para lang="zh">获得/设置 标题前置图标地址，默认为 null，未设置时使用默认图标</para>
+    /// <para lang="en">Gets or sets the leading title icon URL. Default is null. When not set, the default icon is used</para>
     /// </summary>
     [Parameter]
     [JsonIgnore]
     public string? TitleBarIconUrl { get; set; }
 
     /// <summary>
-    /// 获得/设置 标题前置图标点击回调方法 默认 null
+    /// <para lang="zh">获得/设置 标题前置图标点击回调方法，默认为 null</para>
+    /// <para lang="en">Gets or sets the click callback for the leading title icon. Default is null</para>
     /// </summary>
     [Parameter]
     [JsonIgnore]
     public Func<Task>? OnClickTitleBarCallback { get; set; }
-
-    /// <summary>
-    /// <para lang="zh">获得/设置 DockContent 实例</para>
-    /// <para lang="en">Gets or sets the DockContent instance.</para>
-    /// </summary>
     [CascadingParameter]
     [NotNull]
     [JsonIgnore]
@@ -194,9 +208,9 @@ public partial class DockViewComponent
     }
 
     /// <summary>
-    /// 设置 Visible 参数方法
+    /// <para lang="zh">设置组件可见状态</para>
+    /// <para lang="en">Sets the component visibility</para>
     /// </summary>
-    /// <param name="visible"></param>
     public void SetVisible(bool visible)
     {
         Visible = visible;

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -160,8 +160,13 @@ public partial class DockViewComponent
         base.OnParametersSet();
 
         // 根据容器状态同步组件状态
-        if (!string.IsNullOrEmpty(Key) && DockView.ComponentStates.TryGetValue(Key, out var state))
+        if (!string.IsNullOrEmpty(Key))
         {
+            var state = DockView.ComponentStates.GetOrAdd(Key, key => new DockViewComponentState
+            {
+                IsLock = IsLock,
+                Visible = Visible
+            });
             IsLock = state.IsLock;
             Visible = state.Visible;
         }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -186,15 +186,11 @@ public partial class DockViewComponent
                 Render = _rendered
             });
 
-            if (state.Visible != Visible)
-            {
-                state.Visible = Visible;
-            }
-            if (state.IsLock != IsLock)
-            {
-                state.IsLock = IsLock;
-            }
+            // 同步组件状态到容器状态
+            state.Visible = Visible;
+            state.IsLock = IsLock;
 
+            // 同步组件渲染状态
             _rendered = state.Render;
         }
     }
@@ -205,14 +201,5 @@ public partial class DockViewComponent
         {
             await OnClickTitleBarCallback();
         }
-    }
-
-    /// <summary>
-    /// <para lang="zh">设置组件可见状态</para>
-    /// <para lang="en">Sets the component visibility</para>
-    /// </summary>
-    public void SetVisible(bool visible)
-    {
-        Visible = visible;
     }
 }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -163,12 +163,20 @@ public partial class DockViewComponent
         Type = DockViewContentType.Component;
 
         // 增加组件状态
-        DockView?.AddComponentState(new DockViewComponentState()
+        DockView?.AddComponentState(new DockViewComponentState(this)
         {
             Key = Key,
             Visible = Visible,
             IsLock = IsLock
         });
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
     }
 
     private async Task OnClickBar()
@@ -179,17 +187,13 @@ public partial class DockViewComponent
         }
     }
 
-    private bool IsRender()
-    {
-        var state = DockView.GetComponentState(Key);
-        return state.IsRender();
-    }
+    private bool IsRender() => DockView.GetComponentState(Key).IsRender();
 
-    internal object? GetState()
-    {
-        var state = DockView.GetComponentState(Key);
-        return state.GetComponentState(this);
-    }
+    internal object? GetState() => DockView.GetComponentState(Key).GetComponentState(this);
+
+    internal void SetVisible(bool visible) => Visible = visible;
+
+    internal void SetLock(bool isLock) => IsLock = isLock;
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -177,6 +177,13 @@ public partial class DockViewComponent
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
+
+        var state = DockView.GetComponentState(Key);
+        if (state != null)
+        {
+            state.Visible = Visible;
+            state.IsLock = IsLock;
+        }
     }
 
     private async Task OnClickBar()

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -61,6 +61,7 @@ public partial class DockViewComponent
     /// <para lang="en">Gets or sets whether the component is visible. Default is true</para>
     /// </summary>
     [Parameter]
+    [JsonIgnore]
     public bool Visible { get; set; } = true;
 
     /// <summary>
@@ -82,6 +83,7 @@ public partial class DockViewComponent
     /// <para lang="en">Gets or sets whether the component is locked. Default is null. When not set, the DockView configuration is used</para>
     /// </summary>
     [Parameter]
+    [JsonIgnore]
     public bool? IsLock { get; set; }
 
     /// <summary>
@@ -151,12 +153,18 @@ public partial class DockViewComponent
     [Parameter]
     [JsonIgnore]
     public Func<Task>? OnClickTitleBarCallback { get; set; }
+
+    [JsonInclude]
+    [JsonPropertyName("visible")]
+    private bool JsonVisible => DockView.GetComponentState(Key)?.Visible ?? false;
+
+    [JsonInclude]
+    [JsonPropertyName("isLock")]
+    private bool JsonIsLock => DockView.GetComponentState(Key)?.IsLock ?? false;
+
     [CascadingParameter]
     [NotNull]
-    [JsonIgnore]
     private DockViewV2? DockView { get; set; }
-
-    private bool _rendered = false;
 
     /// <summary>
     /// <inheritdoc/>
@@ -166,33 +174,14 @@ public partial class DockViewComponent
         base.OnInitialized();
 
         Type = DockViewContentType.Component;
-    }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    protected override void OnParametersSet()
-    {
-        base.OnParametersSet();
-
-        // 根据容器状态同步组件状态
-        if (!string.IsNullOrEmpty(Key))
+        // 增加组件状态
+        DockView?.AddComponentState(new DockViewComponentState()
         {
-            var state = DockView.ComponentStates.GetOrAdd(Key, key => new DockViewComponentState
-            {
-                Key = key,
-                IsLock = IsLock,
-                Visible = Visible,
-                Render = _rendered
-            });
-
-            // 同步组件状态到容器状态
-            state.Visible = Visible;
-            state.IsLock = IsLock;
-
-            // 同步组件渲染状态
-            _rendered = state.Render;
-        }
+            Key = Key,
+            Visible = Visible,
+            IsLock = IsLock
+        });
     }
 
     private async Task OnClickBar()
@@ -201,5 +190,27 @@ public partial class DockViewComponent
         {
             await OnClickTitleBarCallback();
         }
+    }
+
+    private bool IsRender()
+    {
+        var render = false;
+        var state = DockView.GetComponentState(Key);
+        if (state != null)
+        {
+            render = state.Render && state.Visible;
+        }
+        return render;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="disposing"></param>
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        DockView.RemoveComponentState(Key);
     }
 }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponentBase.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponentBase.cs
@@ -41,6 +41,7 @@ public abstract class DockViewComponentBase : IdComponentBase, IDisposable
     [Parameter]
     [JsonIgnore]
     public RenderFragment? ChildContent { get; set; }
+
     [CascadingParameter]
     private List<DockViewComponentBase>? Parent { get; set; }
 

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponentBase.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponentBase.cs
@@ -8,44 +8,39 @@ using System.Text.Json.Serialization;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// <para lang="zh">DockComponent 基类</para>
-/// <para lang="en">Base class for DockComponent</para>
+/// <para lang="zh">DockView 组件基类</para>
+/// <para lang="en">Base class for DockView components</para>
 /// </summary>
 public abstract class DockViewComponentBase : IdComponentBase, IDisposable
 {
     /// <summary>
-    /// <para lang="zh">获得/设置 渲染类型 默认 Component</para>
-    /// <para lang="en">Gets or sets the render type. Default is Component.</para>
+    /// <para lang="zh">获得/设置 组件渲染类型，默认为 Component</para>
+    /// <para lang="en">Gets or sets the component render type. Default is Component</para>
     /// </summary>
     [Parameter]
     public DockViewContentType Type { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件宽度百分比 默认 null 未设置</para>
-    /// <para lang="en">Gets or sets the component width percentage. Default is null (not set).</para>
+    /// <para lang="zh">获得/设置 组件宽度百分比，默认为 null</para>
+    /// <para lang="en">Gets or sets the component width percentage. Default is null</para>
     /// </summary>
     [Parameter]
     public int? Width { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件高度百分比 默认 null 未设置</para>
-    /// <para lang="en">Gets or sets the component height percentage. Default is null (not set).</para>
+    /// <para lang="zh">获得/设置 组件高度百分比，默认为 null</para>
+    /// <para lang="en">Gets or sets the component height percentage. Default is null</para>
     /// </summary>
     [Parameter]
     public int? Height { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 子组件</para>
-    /// <para lang="en">Gets or sets the child content.</para>
+    /// <para lang="zh">获得/设置 子组件内容</para>
+    /// <para lang="en">Gets or sets the child content</para>
     /// </summary>
     [Parameter]
     [JsonIgnore]
     public RenderFragment? ChildContent { get; set; }
-
-    /// <summary>
-    /// <para lang="zh">获得/设置 DockContent 实例</para>
-    /// <para lang="en">Gets or sets the DockContent instance.</para>
-    /// </summary>
     [CascadingParameter]
     private List<DockViewComponentBase>? Parent { get; set; }
 
@@ -60,8 +55,8 @@ public abstract class DockViewComponentBase : IdComponentBase, IDisposable
     }
 
     /// <summary>
-    /// <para lang="zh">资源销毁方法</para>
-    /// <para lang="en">Resource disposal method</para>
+    /// <para lang="zh">资源释放方法</para>
+    /// <para lang="en">Releases resources</para>
     /// </summary>
     /// <param name="disposing"></param>
     protected virtual void Dispose(bool disposing)
@@ -73,8 +68,8 @@ public abstract class DockViewComponentBase : IdComponentBase, IDisposable
     }
 
     /// <summary>
-    /// <para lang="zh">资源销毁方法</para>
-    /// <para lang="en">Resource disposal method</para>
+    /// <para lang="zh">资源释放方法</para>
+    /// <para lang="en">Releases resources</para>
     /// </summary>
     public void Dispose()
     {

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewConfig.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewConfig.cs
@@ -6,119 +6,121 @@ using System.Text.Json.Serialization;
 
 namespace BootstrapBlazor.Components;
 
+/// <summary>
+/// <para lang="zh">DockView 配置项</para>
+/// <para lang="en">DockView configuration options</para>
+/// </summary>
 class DockViewConfig
 {
     /// <summary>
-    /// <para lang="zh">获得/设置 是否启用本地布局保持 默认 true</para>
-    /// <para lang="en">Gets or sets whether to enable local layout persistence. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否启用本地布局持久化，默认为 true</para>
+    /// <para lang="en">Gets or sets whether local layout persistence is enabled. Default is true</para>
     /// </summary>
     public bool EnableLocalStorage { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否锁定 默认 false</para>
-    /// <para lang="en">Gets or sets whether the component is locked. Default is false.</para>
+    /// <para lang="zh">获得/设置 是否锁定，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the component is locked. Default is false</para>
     /// </summary>
-    /// <remarks>锁定后无法拖动</remarks>
     [JsonPropertyName("lock")]
     public bool IsLock { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示锁定按钮 默认 true 显示</para>
-    /// <para lang="en">Gets or sets whether the lock button is displayed. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示锁定按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the lock button is displayed. Default is true</para>
     /// </summary>
     public bool ShowLock { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否悬浮 默认 false</para>
-    /// <para lang="en">Gets or sets whether the component is floating. Default is false.</para>
+    /// <para lang="zh">获得/设置 是否悬浮，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the component is floating. Default is false</para>
     /// </summary>
-    /// <remarks>锁定后无法拖动</remarks>
     public bool IsFloating { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示可悬浮按钮 默认 true</para>
-    /// <para lang="en">Gets or sets whether the float button is displayed. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示悬浮按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the float button is displayed. Default is true</para>
     /// </summary>
     public bool ShowFloat { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示关闭按钮 默认 true 显示</para>
-    /// <para lang="en">Gets or sets whether the close button is displayed. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示关闭按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the close button is displayed. Default is true</para>
     /// </summary>
     public bool ShowClose { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示图钉按钮 默认 true</para>
-    /// <para lang="en">Gets or sets whether the pin button is displayed. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示图钉按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the pin button is displayed. Default is true</para>
     /// </summary>
     public bool ShowPin { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示最大化按钮 默认 true</para>
-    /// <para lang="en">Gets or sets whether the maximize button is displayed. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示最大化按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the maximize button is displayed. Default is true</para>
     /// </summary>
     public bool ShowMaximize { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 客户端渲染模式 默认 null 客户端默认使用 always onlyWhenVisible 值</para>
-    /// <para lang="en">Gets or sets the client render mode. Default is null, the client will use always onlyWhenVisible value.</para>
+    /// <para lang="zh">获得/设置 客户端渲染模式</para>
+    /// <para lang="en">Gets or sets the client render mode</para>
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public DockViewRenderMode Renderer { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 标签页可见状态改变事件回调</para>
-    /// <para lang="en">Gets or sets the callback for when the tab visibility changes.</para>
+    /// <para lang="zh">获得/设置 标签页可见状态变更回调名称</para>
+    /// <para lang="en">Gets or sets the callback name for tab visibility state changes</para>
     /// </summary>
     public string? PanelVisibleChangedCallback { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件初始化完成事件回调</para>
-    /// <para lang="en">Gets or sets the callback for when the component is initialized.</para>
+    /// <para lang="zh">获得/设置 组件初始化完成回调名称</para>
+    /// <para lang="en">Gets or sets the callback name for component initialization completion</para>
     /// </summary>
     public string? InitializedCallback { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 锁定事件回调</para>
-    /// <para lang="en">Gets or sets the callback for when the lock state changes.</para>
+    /// <para lang="zh">获得/设置 锁定状态变更回调名称</para>
+    /// <para lang="en">Gets or sets the callback name for lock state changes</para>
     /// </summary>
     public string? LockChangedCallback { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 分割栏调整事件回调</para>
-    /// <para lang="en">Gets or sets the callback for when the splitter is adjusted.</para>
+    /// <para lang="zh">获得/设置 分割器调整回调名称</para>
+    /// <para lang="en">Gets or sets the callback name for splitter adjustments</para>
     /// </summary>
     public string? SplitterCallback { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 加载当前激活标签页事件回调</para>
-    /// <para lang="en">Gets or sets the callback for loading the currently active tab.</para>
+    /// <para lang="zh">获得/设置 加载标签页回调名称</para>
+    /// <para lang="en">Gets or sets the callback name for loading tabs</para>
     /// </summary>
     public string? LoadTabs { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 客户端缓存键值</para>
-    /// <para lang="en">Gets or sets the client-side cache key.</para>
+    /// <para lang="zh">获得/设置 客户端缓存键</para>
+    /// <para lang="en">Gets or sets the client-side cache key</para>
     /// </summary>
     public string? LocalStorageKey { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 配置项集合 默认 空集合</para>
-    /// <para lang="en">Gets or sets the configuration items. Default is an empty collection.</para>
+    /// <para lang="zh">获得/设置 配置项集合，默认为空集合</para>
+    /// <para lang="en">Gets or sets the configuration items. Default is an empty collection</para>
     /// </summary>
     [JsonPropertyName("content")]
     [JsonConverter(typeof(DockViewComponentConverter))]
     public List<DockViewComponentBase> Contents { get; set; } = [];
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件主题 默认 null 未设置</para>
-    /// <para lang="en">Gets or sets the component theme. Default is null, not set.</para>
+    /// <para lang="zh">获得/设置 组件主题，默认为 null</para>
+    /// <para lang="en">Gets or sets the component theme. Default is null</para>
     /// </summary>
     public string? Theme { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 布局配置 默认 null 未设置</para>
-    /// <para lang="en">Gets or sets the layout configuration. Default is null, not set.</para>
+    /// <para lang="zh">获得/设置 布局配置，默认为 null</para>
+    /// <para lang="en">Gets or sets the layout configuration. Default is null</para>
     /// </summary>
     public string? LayoutConfig { get; set; }
 }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewConfig.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewConfig.cs
@@ -13,12 +13,6 @@ namespace BootstrapBlazor.Components;
 class DockViewConfig
 {
     /// <summary>
-    /// <para lang="zh">获得/设置 是否首次加载，默认为 false</para>
-    /// <para lang="en">Gets or sets whether it is the first render. Default is false</para>
-    /// </summary>
-    public bool FirstRender { get; set; }
-
-    /// <summary>
     /// <para lang="zh">获得/设置 是否启用本地布局持久化，默认为 true</para>
     /// <para lang="en">Gets or sets whether local layout persistence is enabled. Default is true</para>
     /// </summary>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewConfig.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewConfig.cs
@@ -13,6 +13,12 @@ namespace BootstrapBlazor.Components;
 class DockViewConfig
 {
     /// <summary>
+    /// <para lang="zh">获得/设置 是否首次加载，默认为 false</para>
+    /// <para lang="en">Gets or sets whether it is the first render. Default is false</para>
+    /// </summary>
+    public bool FirstRender { get; set; }
+
+    /// <summary>
     /// <para lang="zh">获得/设置 是否启用本地布局持久化，默认为 true</para>
     /// <para lang="en">Gets or sets whether local layout persistence is enabled. Default is true</para>
     /// </summary>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewContent.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewContent.cs
@@ -10,13 +10,13 @@ namespace BootstrapBlazor.Components;
 
 /// <summary>
 /// <para lang="zh">DockContent 类对标 content 配置项</para>
-/// <para lang="en">DockContent class corresponds to the content configuration item.</para>
+/// <para lang="en">DockContent class corresponds to the content configuration item</para>
 /// </summary>
 public class DockViewContent : DockViewComponentBase
 {
     /// <summary>
     /// <para lang="zh">获得/设置 子项集合</para>
-    /// <para lang="en">Gets or sets the collection of child items.</para>
+    /// <para lang="en">Gets or sets the collection of child items</para>
     /// </summary>
     [JsonConverter(typeof(DockViewComponentConverter))]
     [JsonPropertyName("content")]

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewDropdownIcon.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewDropdownIcon.razor.cs
@@ -10,10 +10,6 @@ namespace BootstrapBlazor.Components;
 /// </summary>
 public partial class DockViewDropdownIcon
 {
-    /// <summary>
-    /// <para lang="zh">获得 样式字符串</para>
-    /// <para lang="en">Gets the CSS class string.</para>
-    /// </summary>
     private string? ClassString => CssBuilder.Default("dropdown dropdown-center bb-dockview-control-icon")
         .AddClass($"bb-dockview-control-icon-{IconName}")
         .Build();

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewIcon.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewIcon.razor.cs
@@ -15,30 +15,25 @@ public partial class DockViewIcon
 {
     /// <summary>
     /// <para lang="zh">获得/设置 资源文件接口实例</para>
-    /// <para lang="en">Gets or sets the resource file interface instance.</para>
+    /// <para lang="en">Gets or sets the resource file interface instance</para>
     /// </summary>
     [Inject, NotNull]
     protected IStringLocalizer<DockViewIcon>? Localizer { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 图标名称</para>
-    /// <para lang="en">Gets or sets the icon name.</para>
+    /// <para lang="en">Gets or sets the icon name</para>
     /// </summary>
     [Parameter, NotNull]
     [EditorRequired]
     public string? IconName { get; set; }
-
-    /// <summary>
-    /// <para lang="zh">获得 样式字符串</para>
-    /// <para lang="en">Gets the CSS class string.</para>
-    /// </summary>
     private string? ClassString => CssBuilder.Default("bb-dockview-control-icon")
         .AddClass($"bb-dockview-control-icon-{IconName}")
         .Build();
 
     /// <summary>
     /// <para lang="zh">获得 图标地址</para>
-    /// <para lang="en">Gets the icon URL.</para>
+    /// <para lang="en">Gets the icon URL</para>
     /// </summary>
     protected string Href => $"./_content/BootstrapBlazor.DockView/icon/dockview.svg#{IconName}";
 

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewOptions.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewOptions.cs
@@ -5,22 +5,26 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// DockView 组件配置类
+/// <para lang="zh">DockView 组件配置项</para>
+/// <para lang="en">DockView component options</para>
 /// </summary>
 class DockViewOptions
 {
     /// <summary>
-    /// 获得/设置 组件本地化版本信息
+    /// <para lang="zh">获得/设置 组件版本信息</para>
+    /// <para lang="en">Gets or sets the component version information</para>
     /// </summary>
     public string? Version { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否开启本地存储 默认 null 未设置
+    /// <para lang="zh">获得/设置 是否启用本地存储，默认为 null</para>
+    /// <para lang="en">Gets or sets whether local storage is enabled. Default is null</para>
     /// </summary>
     public bool? EnableLocalStorage { get; set; }
 
     /// <summary>
-    /// 获得/设置 本地存储前缀 默认 bb-dock
+    /// <para lang="zh">获得/设置 本地存储前缀，默认为 bb-dock</para>
+    /// <para lang="en">Gets or sets the local storage prefix. Default is bb-dock</para>
     /// </summary>
     public string? LocalStoragePrefix { get; set; }
 }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewRenderMode.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewRenderMode.cs
@@ -21,11 +21,5 @@ public enum DockViewRenderMode
     /// <para lang="zh">始终渲染</para>
     /// <para lang="en">Always render</para>
     /// </summary>
-    Always,
-
-    /// <summary>
-    /// <para lang="zh">部分渲染 可见版面渲染 不可见版面异步渲染</para>
-    /// <para lang="en"></para>
-    /// </summary>
-    Partial
+    Always
 }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewRenderMode.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewRenderMode.cs
@@ -12,14 +12,14 @@ namespace BootstrapBlazor.Components;
 public enum DockViewRenderMode
 {
     /// <summary>
-    /// <para lang="zh">始终渲染</para>
-    /// <para lang="en">Always render</para>
-    /// </summary>
-    Always,
-
-    /// <summary>
     /// <para lang="zh">可见时渲染</para>
     /// <para lang="en">Render when visible</para>
     /// </summary>
-    OnlyWhenVisible
+    OnlyWhenVisible,
+
+    /// <summary>
+    /// <para lang="zh">始终渲染</para>
+    /// <para lang="en">Always render</para>
+    /// </summary>
+    Always
 }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewRenderMode.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewRenderMode.cs
@@ -12,14 +12,14 @@ namespace BootstrapBlazor.Components;
 public enum DockViewRenderMode
 {
     /// <summary>
-    /// <para lang="zh">可见时渲染</para>
-    /// <para lang="en">Render when visible</para>
-    /// </summary>
-    OnlyWhenVisible,
-
-    /// <summary>
     /// <para lang="zh">始终渲染</para>
     /// <para lang="en">Always render</para>
     /// </summary>
-    Always
+    Always,
+
+    /// <summary>
+    /// <para lang="zh">可见时渲染</para>
+    /// <para lang="en">Render when visible</para>
+    /// </summary>
+    OnlyWhenVisible
 }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewTitleBar.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewTitleBar.razor.cs
@@ -7,24 +7,28 @@ using Microsoft.AspNetCore.Components;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// DockViewTitle 组件
+/// <para lang="zh">DockView 标题栏组件</para>
+/// <para lang="en">DockView title bar component</para>
 /// </summary>
 public partial class DockViewTitleBar
 {
     /// <summary>
-    /// 获得/设置 标题前置图标点击回调方法 默认 null
+    /// <para lang="zh">获得/设置 标题前置图标点击回调方法，默认为 null</para>
+    /// <para lang="en">Gets or sets the click callback for the leading title icon. Default is null</para>
     /// </summary>
     [Parameter]
     public Func<Task>? OnClickBarCallback { get; set; }
 
     /// <summary>
-    /// 获得/设置 标题前置图标 默认 null 未设置使用默认图标
+    /// <para lang="zh">获得/设置 标题前置图标，默认为 null，未设置时使用默认图标</para>
+    /// <para lang="en">Gets or sets the leading title icon. Default is null. When not set, the default icon is used</para>
     /// </summary>
     [Parameter]
     public string? BarIcon { get; set; }
 
     /// <summary>
-    /// 获得/设置 标题前置图标 Url 默认 null 未设置使用默认图标
+    /// <para lang="zh">获得/设置 标题前置图标地址，默认为 null，未设置时使用默认图标</para>
+    /// <para lang="en">Gets or sets the leading title icon URL. Default is null. When not set, the default icon is used</para>
     /// </summary>
     [Parameter]
     public string? BarIconUrl { get; set; }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor
@@ -3,12 +3,6 @@
 
 <div @attributes="@AdditionalAttributes" id="@Id" class="@ClassString">
     <template>
-        <CascadingValue Value="this" IsFixed="true">
-            <CascadingValue Value="_components" IsFixed="true">
-                @ChildContent
-            </CascadingValue>
-        </CascadingValue>
-
         @if (DockView == null)
         {
             <DockViewIcon IconName="bar"></DockViewIcon>
@@ -24,5 +18,11 @@
             <DockViewIcon IconName="pushpin"></DockViewIcon>
             <DockViewDropdownIcon IconName="dropdown"></DockViewDropdownIcon>
         }
+
+        <CascadingValue Value="this" IsFixed="true">
+            <CascadingValue Value="_components" IsFixed="true">
+                @ChildContent
+            </CascadingValue>
+        </CascadingValue>
     </template>
 </div>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor
@@ -3,6 +3,12 @@
 
 <div @attributes="@AdditionalAttributes" id="@Id" class="@ClassString">
     <template>
+        <CascadingValue Value="this" IsFixed="true">
+            <CascadingValue Value="_components" IsFixed="true">
+                @ChildContent
+            </CascadingValue>
+        </CascadingValue>
+
         @if (DockView == null)
         {
             <DockViewIcon IconName="bar"></DockViewIcon>
@@ -18,11 +24,5 @@
             <DockViewIcon IconName="pushpin"></DockViewIcon>
             <DockViewDropdownIcon IconName="dropdown"></DockViewDropdownIcon>
         }
-
-        <CascadingValue Value="this" IsFixed="true">
-            <CascadingValue Value="_components" IsFixed="true">
-                @ChildContent
-            </CascadingValue>
-        </CascadingValue>
     </template>
 </div>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -249,7 +249,7 @@ public partial class DockViewV2 : IDisposable
     /// <para lang="zh">获得 当前布局 JSON 字符串</para>
     /// <para lang="en">Gets the current layout JSON string</para>
     /// </summary>
-    public Task<string?> SaveLayout() => InvokeAsync<string?>("save", Id);
+    public Task<string?> SaveLayout() => InvokeAsync<string>("save", Id);
 
     private Task OnThemeChangedAsync(string themeName)
     {
@@ -341,6 +341,7 @@ public partial class DockViewV2 : IDisposable
     [JSInvokable]
     public Task LoadTabs(List<string> tabs)
     {
+        // 注意渲染方式 DockViewRenderMode 为 DockViewRenderMode.OnlyWhenVisible 时此逻辑生效
         _loadTabs = tabs.ToHashSet();
         foreach (var componnet in _componentStates)
         {
@@ -354,6 +355,11 @@ public partial class DockViewV2 : IDisposable
 
     internal void AddComponentState(DockViewComponentState state)
     {
+        if (Renderer == DockViewRenderMode.Always)
+        {
+            return;
+        }
+
         if (!string.IsNullOrEmpty(state.Key))
         {
             _componentStates.TryAdd(state.Key, state);
@@ -362,6 +368,11 @@ public partial class DockViewV2 : IDisposable
 
     internal void RemoveComponentState(string? key)
     {
+        if (Renderer == DockViewRenderMode.Always)
+        {
+            return;
+        }
+
         if (!string.IsNullOrEmpty(key))
         {
             _componentStates.TryRemove(key, out _);
@@ -371,12 +382,22 @@ public partial class DockViewV2 : IDisposable
     internal DockViewComponentState? GetComponentState(string? key)
     {
         DockViewComponentState? state = null;
-        if (!string.IsNullOrEmpty(key) && _componentStates.TryGetValue(key, out var _state))
+        if (Renderer == DockViewRenderMode.OnlyWhenVisible)
         {
-            state = _state;
+            if (!string.IsNullOrEmpty(key) && _componentStates.TryGetValue(key, out var _state))
+            {
+                state = _state;
+            }
         }
+
         return state;
     }
+
+    internal bool IsRender(string? key) => Renderer switch
+    {
+        DockViewRenderMode.OnlyWhenVisible => GetComponentState(key)?.IsRender() ?? false,
+        _ => true
+    };
 
     private void Dispose(bool disposing)
     {

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Configuration;
+using System.Collections.Concurrent;
 
 namespace BootstrapBlazor.Components;
 
@@ -170,6 +171,11 @@ public partial class DockViewV2 : IDisposable
     private DockViewOptions? _options = null;
 
     /// <summary>
+    /// <para lang="zh">组件状态集合</para>
+    /// </summary>
+    internal ConcurrentDictionary<string, DockViewComponentState> ComponentStates { get; set; } = [];
+
+    /// <summary>
     /// <inheritdoc/>
     /// </summary>
     protected override void OnInitialized()
@@ -274,11 +280,57 @@ public partial class DockViewV2 : IDisposable
     /// <para lang="en">Tab close callback method called by JavaScript</para>
     /// </summary>
     [JSInvokable]
-    public async Task PanelVisibleChangedCallbackAsync(string title, bool status)
+    public async Task PanelVisibleChangedCallbackAsync(string key, bool status)
     {
+        // 同步更新组件可见状态
+        ComponentStates.AddOrUpdate(key, key =>
+        {
+            return new DockViewComponentState()
+            {
+                Key = key,
+                Visible = status
+            };
+        }, (key, v) =>
+        {
+            v.Visible = status;
+            return v;
+        });
+
+        // 通知订阅者
         if (OnVisibleStateChangedAsync != null)
         {
-            await OnVisibleStateChangedAsync(title, status);
+            await OnVisibleStateChangedAsync(key, status);
+        }
+    }
+
+    /// <summary>
+    /// <para lang="zh">锁定回调方法 由 JavaScript 调用</para>
+    /// <para lang="en">Lock callback method called by JavaScript</para>
+    /// </summary>
+    [JSInvokable]
+    public async Task LockChangedCallbackAsync(string[] panels, bool state)
+    {
+        // 同步更新组件锁定状态
+        foreach (var panel in panels)
+        {
+            ComponentStates.AddOrUpdate(panel, key =>
+            {
+                return new DockViewComponentState()
+                {
+                    Key = key,
+                    IsLock = state
+                };
+            }, (key, v) =>
+            {
+                v.IsLock = state;
+                return v;
+            });
+        }
+
+        // 通知订阅者
+        if (OnLockChangedCallbackAsync != null)
+        {
+            await OnLockChangedCallbackAsync(panels, state);
         }
     }
 
@@ -293,11 +345,7 @@ public partial class DockViewV2 : IDisposable
     public Task LoadTabs(List<string> tabs)
     {
         // 客户端请求渲染当前激活的标签
-        _loadTabs.Clear();
-        foreach (var tab in tabs)
-        {
-            _loadTabs.Add(tab);
-        }
+        _loadTabs = tabs.ToHashSet();
 
         StateHasChanged();
         return Task.CompletedTask;
@@ -310,26 +358,12 @@ public partial class DockViewV2 : IDisposable
     /// <param name="key"></param>
     public bool ShowTab(string? key)
     {
-        // TODO: Partial 模式下使用临时回滚稍后完善
         if (Renderer == DockViewRenderMode.Always)
         {
             return true;
         }
 
         return _loadTabs.Contains(key ?? string.Empty);
-    }
-
-    /// <summary>
-    /// <para lang="zh">锁定回调方法 由 JavaScript 调用</para>
-    /// <para lang="en">Lock callback method called by JavaScript</para>
-    /// </summary>
-    [JSInvokable]
-    public async Task LockChangedCallbackAsync(string[] panels, bool state)
-    {
-        if (OnLockChangedCallbackAsync != null)
-        {
-            await OnLockChangedCallbackAsync(panels, state);
-        }
     }
 
     /// <summary>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -379,7 +379,27 @@ public partial class DockViewV2 : IDisposable
         }
     }
 
-    internal DockViewComponentState? GetComponentState(string? key)
+    internal void UpdateComponentState(string? key, bool visible, bool? isLock)
+    {
+        if (Renderer == DockViewRenderMode.Always)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(key) && _componentStates.TryGetValue(key, out var state))
+        {
+            state.Visible = visible;
+            state.IsLock = isLock;
+        }
+    }
+
+    internal bool IsRender(string? key) => Renderer switch
+    {
+        DockViewRenderMode.OnlyWhenVisible => GetComponentState(key)?.IsRender() ?? false,
+        _ => true
+    };
+
+    private DockViewComponentState? GetComponentState(string? key)
     {
         DockViewComponentState? state = null;
         if (Renderer == DockViewRenderMode.OnlyWhenVisible)
@@ -392,12 +412,6 @@ public partial class DockViewV2 : IDisposable
 
         return state;
     }
-
-    internal bool IsRender(string? key) => Renderer switch
-    {
-        DockViewRenderMode.OnlyWhenVisible => GetComponentState(key)?.IsRender() ?? false,
-        _ => true
-    };
 
     private void Dispose(bool disposing)
     {

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -149,6 +149,9 @@ public partial class DockViewV2 : IDisposable
     [Parameter]
     public DockViewTheme Theme { get; set; } = DockViewTheme.Light;
 
+    /// <summary>
+    /// 嵌套 DockView 时生效防止生成冗余的 DOM 结构
+    /// </summary>
     [CascadingParameter]
     private DockViewV2? DockView { get; set; }
 
@@ -331,6 +334,19 @@ public partial class DockViewV2 : IDisposable
         }
     }
 
+    /// <summary>
+    /// <para lang="zh">分割器回调方法，由 JavaScript 调用</para>
+    /// <para lang="en">Splitter callback method called by JavaScript</para>
+    /// </summary>
+    [JSInvokable]
+    public async Task SplitterCallbackAsync()
+    {
+        if (OnSplitterCallbackAsync != null)
+        {
+            await OnSplitterCallbackAsync();
+        }
+    }
+
     private HashSet<string> _loadTabs = new();
 
     /// <summary>
@@ -360,19 +376,6 @@ public partial class DockViewV2 : IDisposable
             StateHasChanged();
         }
         return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// <para lang="zh">分割器回调方法，由 JavaScript 调用</para>
-    /// <para lang="en">Splitter callback method called by JavaScript</para>
-    /// </summary>
-    [JSInvokable]
-    public async Task SplitterCallbackAsync()
-    {
-        if (OnSplitterCallbackAsync != null)
-        {
-            await OnSplitterCallbackAsync();
-        }
     }
 
     private void Dispose(bool disposing)

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -344,26 +344,20 @@ public partial class DockViewV2 : IDisposable
     [JSInvokable]
     public Task LoadTabs(List<string> tabs)
     {
-        // 客户端请求渲染当前激活的标签
         _loadTabs = tabs.ToHashSet();
 
-        StateHasChanged();
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// <para lang="zh">检查指定 Key 值 DockviewComponent 是否处于激活状态</para>
-    /// <para lang="en">Checks whether the DockviewComponent with the specified key is active.</para>
-    /// </summary>
-    /// <param name="key"></param>
-    public bool ShowTab(string? key)
-    {
-        if (Renderer == DockViewRenderMode.Always)
+        bool rendered = false;
+        foreach (var key in ComponentStates.Keys)
         {
-            return true;
+            var state = ComponentStates[key];
+            state.Visible = _loadTabs.Contains(key);
         }
 
-        return _loadTabs.Contains(key ?? string.Empty);
+        if (rendered)
+        {
+            StateHasChanged();
+        }
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -203,9 +203,9 @@ public partial class DockViewV2 : IDisposable
     /// <summary>
     /// <inheritdoc />
     /// </summary>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetOptions());
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetOptions(true));
 
-    private DockViewConfig GetOptions() => new()
+    private DockViewConfig GetOptions(bool firstRender = false) => new()
     {
         EnableLocalStorage = EnableLocalStorage ?? _options.EnableLocalStorage ?? false,
         LocalStorageKey = $"{GetPrefixKey()}-{Name}-{GetVersion()}",
@@ -224,7 +224,8 @@ public partial class DockViewV2 : IDisposable
         LockChangedCallback = nameof(LockChangedCallbackAsync),
         SplitterCallback = nameof(SplitterCallbackAsync),
         Contents = _components,
-        LoadTabs = nameof(LoadTabs)
+        LoadTabs = nameof(LoadTabs),
+        FirstRender = firstRender
     };
 
     private string GetVersion() => Version ?? _options.Version ?? "v1";

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -278,18 +278,13 @@ public partial class DockViewV2 : IDisposable
     public async Task PanelVisibleChangedCallbackAsync(string key, bool status)
     {
         // 同步更新组件可见状态
-        _componentStates.AddOrUpdate(key, key =>
+        if (_componentStates.TryGetValue(key, out var state))
         {
-            return new DockViewComponentState()
-            {
-                Key = key,
-                Visible = status
-            };
-        }, (key, v) =>
-        {
-            v.Visible = status;
-            return v;
-        });
+            state.Visible = status;
+
+            // 同步可见状态到组件实例
+            state.Component.SetVisible(status);
+        }
 
         // 通知订阅者
         if (OnVisibleStateChangedAsync != null)
@@ -303,29 +298,24 @@ public partial class DockViewV2 : IDisposable
     /// <para lang="en">Lock state change callback method called by JavaScript</para>
     /// </summary>
     [JSInvokable]
-    public async Task LockChangedCallbackAsync(string[] panels, bool state)
+    public async Task LockChangedCallbackAsync(string[] panels, bool locked)
     {
         // 同步更新组件锁定状态
         foreach (var panel in panels)
         {
-            _componentStates.AddOrUpdate(panel, key =>
+            if (_componentStates.TryGetValue(panel, out var state))
             {
-                return new DockViewComponentState()
-                {
-                    Key = key,
-                    IsLock = state
-                };
-            }, (key, v) =>
-            {
-                v.IsLock = state;
-                return v;
-            });
+                state.IsLock = locked;
+
+                // 同步可见状态到组件实例
+                state.Component.SetLock(locked);
+            }
         }
 
         // 通知订阅者
         if (OnLockChangedCallbackAsync != null)
         {
-            await OnLockChangedCallbackAsync(panels, state);
+            await OnLockChangedCallbackAsync(panels, locked);
         }
     }
 

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -171,12 +171,7 @@ public partial class DockViewV2 : IDisposable
 
     [NotNull]
     private DockViewOptions? _options = null;
-
-    /// <summary>
-    /// <para lang="zh">获得/设置 组件状态集合</para>
-    /// <para lang="en">Gets or sets the component state collection</para>
-    /// </summary>
-    internal ConcurrentDictionary<string, DockViewComponentState> ComponentStates { get; set; } = [];
+    private ConcurrentDictionary<string, DockViewComponentState> _componentStates = new();
 
     /// <summary>
     /// <inheritdoc/>
@@ -283,7 +278,7 @@ public partial class DockViewV2 : IDisposable
     public async Task PanelVisibleChangedCallbackAsync(string key, bool status)
     {
         // 同步更新组件可见状态
-        ComponentStates.AddOrUpdate(key, key =>
+        _componentStates.AddOrUpdate(key, key =>
         {
             return new DockViewComponentState()
             {
@@ -313,7 +308,7 @@ public partial class DockViewV2 : IDisposable
         // 同步更新组件锁定状态
         foreach (var panel in panels)
         {
-            ComponentStates.AddOrUpdate(panel, key =>
+            _componentStates.AddOrUpdate(panel, key =>
             {
                 return new DockViewComponentState()
                 {
@@ -357,25 +352,40 @@ public partial class DockViewV2 : IDisposable
     public Task LoadTabs(List<string> tabs)
     {
         _loadTabs = tabs.ToHashSet();
-
-        bool rendered = false;
-        foreach (var key in ComponentStates.Keys)
+        foreach (var componnet in _componentStates)
         {
-            var state = ComponentStates[key];
-
-            var render = _loadTabs.Contains(key);
-            if (render != state.Render)
-            {
-                state.Render = render;
-                rendered = true;
-            }
+            // 标记是否渲染
+            componnet.Value.Render = tabs.Contains(componnet.Key);
         }
+        StateHasChanged();
 
-        if (rendered)
-        {
-            StateHasChanged();
-        }
         return Task.CompletedTask;
+    }
+
+    internal void AddComponentState(DockViewComponentState state)
+    {
+        if (!string.IsNullOrEmpty(state.Key))
+        {
+            _componentStates.TryAdd(state.Key, state);
+        }
+    }
+
+    internal void RemoveComponentState(string? key)
+    {
+        if (!string.IsNullOrEmpty(key))
+        {
+            _componentStates.TryRemove(key, out _);
+        }
+    }
+
+    internal DockViewComponentState? GetComponentState(string? key)
+    {
+        DockViewComponentState? state = null;
+        if (!string.IsNullOrEmpty(key) && _componentStates.TryGetValue(key, out var _state))
+        {
+            state = _state;
+        }
+        return state;
     }
 
     private void Dispose(bool disposing)

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -350,7 +350,13 @@ public partial class DockViewV2 : IDisposable
         foreach (var key in ComponentStates.Keys)
         {
             var state = ComponentStates[key];
-            state.Visible = _loadTabs.Contains(key);
+
+            var render = _loadTabs.Contains(key);
+            if (render != state.Render)
+            {
+                state.Render = render;
+                rendered = true;
+            }
         }
 
         if (rendered)

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -172,6 +172,7 @@ public partial class DockViewV2 : IDisposable
     [NotNull]
     private DockViewOptions? _options = null;
     private ConcurrentDictionary<string, DockViewComponentState> _componentStates = new();
+    private bool _firstLoad = true;
 
     /// <summary>
     /// <inheritdoc/>
@@ -203,9 +204,9 @@ public partial class DockViewV2 : IDisposable
     /// <summary>
     /// <inheritdoc />
     /// </summary>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetOptions(true));
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetOptions());
 
-    private DockViewConfig GetOptions(bool firstRender = false) => new()
+    private DockViewConfig GetOptions() => new()
     {
         EnableLocalStorage = EnableLocalStorage ?? _options.EnableLocalStorage ?? false,
         LocalStorageKey = $"{GetPrefixKey()}-{Name}-{GetVersion()}",
@@ -225,7 +226,7 @@ public partial class DockViewV2 : IDisposable
         SplitterCallback = nameof(SplitterCallbackAsync),
         Contents = _components,
         LoadTabs = nameof(LoadTabs),
-        FirstRender = firstRender
+        FirstRender = _firstLoad
     };
 
     private string GetVersion() => Version ?? _options.Version ?? "v1";
@@ -265,6 +266,7 @@ public partial class DockViewV2 : IDisposable
     [JSInvokable]
     public async Task InitializedCallbackAsync()
     {
+        _firstLoad = false;
         if (OnInitializedCallbackAsync != null)
         {
             await OnInitializedCallbackAsync();

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -172,7 +172,6 @@ public partial class DockViewV2 : IDisposable
     [NotNull]
     private DockViewOptions? _options = null;
     private ConcurrentDictionary<string, DockViewComponentState> _componentStates = new();
-    private bool _firstLoad = true;
 
     /// <summary>
     /// <inheritdoc/>
@@ -204,9 +203,9 @@ public partial class DockViewV2 : IDisposable
     /// <summary>
     /// <inheritdoc />
     /// </summary>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetOptions());
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetOptions(true));
 
-    private DockViewConfig GetOptions() => new()
+    private DockViewConfig GetOptions(bool firstRender = false) => new()
     {
         EnableLocalStorage = EnableLocalStorage ?? _options.EnableLocalStorage ?? false,
         LocalStorageKey = $"{GetPrefixKey()}-{Name}-{GetVersion()}",
@@ -226,7 +225,7 @@ public partial class DockViewV2 : IDisposable
         SplitterCallback = nameof(SplitterCallbackAsync),
         Contents = _components,
         LoadTabs = nameof(LoadTabs),
-        FirstRender = _firstLoad
+        FirstRender = firstRender
     };
 
     private string GetVersion() => Version ?? _options.Version ?? "v1";
@@ -266,7 +265,6 @@ public partial class DockViewV2 : IDisposable
     [JSInvokable]
     public async Task InitializedCallbackAsync()
     {
-        _firstLoad = false;
         if (OnInitializedCallbackAsync != null)
         {
             await OnInitializedCallbackAsync();

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -203,9 +203,9 @@ public partial class DockViewV2 : IDisposable
     /// <summary>
     /// <inheritdoc />
     /// </summary>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetOptions(true));
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetOptions());
 
-    private DockViewConfig GetOptions(bool firstRender = false) => new()
+    private DockViewConfig GetOptions() => new()
     {
         EnableLocalStorage = EnableLocalStorage ?? _options.EnableLocalStorage ?? false,
         LocalStorageKey = $"{GetPrefixKey()}-{Name}-{GetVersion()}",
@@ -224,8 +224,7 @@ public partial class DockViewV2 : IDisposable
         LockChangedCallback = nameof(LockChangedCallbackAsync),
         SplitterCallback = nameof(SplitterCallbackAsync),
         Contents = _components,
-        LoadTabs = nameof(LoadTabs),
-        FirstRender = firstRender
+        LoadTabs = nameof(LoadTabs)
     };
 
     private string GetVersion() => Version ?? _options.Version ?? "v1";

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -9,13 +9,14 @@ using System.Collections.Concurrent;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// DockViewV2 组件
+/// <para lang="zh">DockViewV2 组件</para>
+/// <para lang="en">DockViewV2 component</para>
 /// </summary>
 public partial class DockViewV2 : IDisposable
 {
     /// <summary>
-    /// <para lang="zh">获得/设置 DockView 名称 默认 null 用于本地存储识别</para>
-    /// <para lang="en">Gets or sets the DockView name. Default is null, used for local storage identification.</para>
+    /// <para lang="zh">获得/设置 DockView 名称，默认为 null，用于本地存储标识</para>
+    /// <para lang="en">Gets or sets the DockView name. Default is null and it is used for local storage identification</para>
     /// </summary>
     [Parameter]
     [EditorRequired]
@@ -24,128 +25,126 @@ public partial class DockViewV2 : IDisposable
 
     /// <summary>
     /// <para lang="zh">获得/设置 布局配置</para>
-    /// <para lang="en">Gets or sets the layout configuration.</para>
+    /// <para lang="en">Gets or sets the layout configuration</para>
     /// </summary>
     [Parameter]
     public string? LayoutConfig { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示关闭按钮 默认为 true</para>
-    /// <para lang="en">Gets or sets whether to show the close button. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示关闭按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the close button is displayed. Default is true</para>
     /// </summary>
     [Parameter]
     public bool ShowClose { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否锁定 默认 false</para>
-    /// <para lang="en">Gets or sets whether to lock. Default is false.</para>
+    /// <para lang="zh">获得/设置 是否锁定，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the component is locked. Default is false</para>
     /// </summary>
-    /// <remarks>锁定后无法拖动</remarks>
     [Parameter]
     public bool IsLock { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示锁定按钮 默认 true</para>
-    /// <para lang="en">Gets or sets whether to show the lock button. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示锁定按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the lock button is displayed. Default is true</para>
     /// </summary>
     [Parameter]
     public bool ShowLock { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示最大化按钮 默认 true</para>
-    /// <para lang="en">Gets or sets whether to show the maximize button. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示最大化按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the maximize button is displayed. Default is true</para>
     /// </summary>
     [Parameter]
     public bool ShowMaximize { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否悬浮 默认 false</para>
-    /// <para lang="en">Gets or sets whether to float. Default is false.</para>
+    /// <para lang="zh">获得/设置 是否悬浮，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the component is floating. Default is false</para>
     /// </summary>
     [Parameter]
     public bool IsFloating { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示可悬浮按钮 默认 true</para>
-    /// <para lang="en">Gets or sets whether to show the float button. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示悬浮按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the float button is displayed. Default is true</para>
     /// </summary>
     [Parameter]
     public bool ShowFloat { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示显示图钉按钮 默认 true</para>
-    /// <para lang="en">Gets or sets whether to show the pin button. Default is true.</para>
+    /// <para lang="zh">获得/设置 是否显示图钉按钮，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the pin button is displayed. Default is true</para>
     /// </summary>
     [Parameter]
     public bool ShowPin { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 客户端渲染模式 默认 <see cref="DockViewRenderMode.OnlyWhenVisible"/> 客户端默认使用 always onlyWhenVisible 值</para>
-    /// <para lang="en">Gets or sets the client render mode. Default is <see cref="DockViewRenderMode.OnlyWhenVisible"/>. The client defaults to using always onlyWhenVisible values.</para>
+    /// <para lang="zh">获得/设置 客户端渲染模式，默认为 <see cref="DockViewRenderMode.OnlyWhenVisible"/></para>
+    /// <para lang="en">Gets or sets the client render mode. Default is <see cref="DockViewRenderMode.OnlyWhenVisible"/></para>
     /// </summary>
     [Parameter]
     public DockViewRenderMode Renderer { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 锁定状态回调此方法</para>
-    /// <para lang="en">Gets or sets the callback method for lock state changes.</para>
+    /// <para lang="zh">获得/设置 锁定状态变更回调方法</para>
+    /// <para lang="en">Gets or sets the callback for lock state changes</para>
     /// </summary>
     [Parameter]
     public Func<string[], bool, Task>? OnLockChangedCallbackAsync { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 标签关闭时回调此方法</para>
-    /// <para lang="en">Gets or sets the callback method for when a tab is closed.</para>
+    /// <para lang="zh">获得/设置 标签页可见状态变更回调方法</para>
+    /// <para lang="en">Gets or sets the callback for tab visibility state changes</para>
     /// </summary>
-    /// <remarks>可用于第三方组件显示标签页状态更新</remarks>
     [Parameter]
     public Func<string, bool, Task>? OnVisibleStateChangedAsync { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 标签页调整大小完成时回调此方法</para>
-    /// <para lang="en">Gets or sets the callback method for when a tab is resized.</para>
+    /// <para lang="zh">获得/设置 标签页调整大小完成回调方法</para>
+    /// <para lang="en">Gets or sets the callback for when tab resizing is completed</para>
     /// </summary>
     [Parameter]
     public Func<Task>? OnSplitterCallbackAsync { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 客户端组件脚本初始化完成后回调此方法</para>
-    /// <para lang="en">Gets or sets the callback method for when the client component script initialization is complete.</para>
+    /// <para lang="zh">获得/设置 客户端组件脚本初始化完成回调方法</para>
+    /// <para lang="en">Gets or sets the callback for when client component script initialization is complete</para>
     /// </summary>
     [Parameter]
     public Func<Task>? OnInitializedCallbackAsync { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 子组件</para>
-    /// <para lang="en">Gets or sets the child components.</para>
+    /// <para lang="zh">获得/设置 子组件内容</para>
+    /// <para lang="en">Gets or sets the child content</para>
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 版本设置 默认 null 未设置 用于本地配置 可通过全局统一配置</para>
-    /// <para lang="en">Gets or sets the version. Default is null. Used for local configuration and can be configured globally.</para>
+    /// <para lang="zh">获得/设置 版本信息，默认为 null，未设置时可通过全局配置提供</para>
+    /// <para lang="en">Gets or sets the version information. Default is null. When not set, it can be provided by global configuration</para>
     /// </summary>
     [Parameter]
     public string? Version { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否启用本地存储布局 默认 null 未设置</para>
-    /// <para lang="en">Gets or sets whether to enable local storage layout. Default is null. Not set.</para>
+    /// <para lang="zh">获得/设置 是否启用本地存储布局，默认为 null</para>
+    /// <para lang="en">Gets or sets whether local storage layout is enabled. Default is null</para>
     /// </summary>
     [Parameter]
     public bool? EnableLocalStorage { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 本地存储前缀 默认 bb-dock</para>
-    /// <para lang="en">Gets or sets the local storage prefix. Default is bb-dock.</para>
+    /// <para lang="zh">获得/设置 本地存储前缀，默认为 bb-dock</para>
+    /// <para lang="en">Gets or sets the local storage prefix. Default is bb-dock</para>
     /// </summary>
     [Parameter]
     public string? LocalStoragePrefix { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 DockView 组件主题 默认 Light</para>
-    /// <para lang="en">Gets or sets the DockView component theme. Default is Light.</para>
+    /// <para lang="zh">获得/设置 DockView 组件主题，默认为 Light</para>
+    /// <para lang="en">Gets or sets the DockView component theme. Default is Light</para>
     /// </summary>
     [Parameter]
     public DockViewTheme Theme { get; set; } = DockViewTheme.Light;
@@ -171,7 +170,8 @@ public partial class DockViewV2 : IDisposable
     private DockViewOptions? _options = null;
 
     /// <summary>
-    /// <para lang="zh">组件状态集合</para>
+    /// <para lang="zh">获得/设置 组件状态集合</para>
+    /// <para lang="en">Gets or sets the component state collection</para>
     /// </summary>
     internal ConcurrentDictionary<string, DockViewComponentState> ComponentStates { get; set; } = [];
 
@@ -192,7 +192,6 @@ public partial class DockViewV2 : IDisposable
     /// <inheritdoc/>
     /// </summary>
     /// <param name="firstRender"></param>
-    /// <returns></returns>
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
@@ -236,9 +235,8 @@ public partial class DockViewV2 : IDisposable
 
     /// <summary>
     /// <para lang="zh">重置为默认布局</para>
-    /// <para lang="en">Resets to the default layout.</para>
+    /// <para lang="en">Resets to the default layout</para>
     /// </summary>
-    /// <returns></returns>
     public async Task Reset(string? layoutConfig = null)
     {
         var options = GetOptions();
@@ -250,10 +248,9 @@ public partial class DockViewV2 : IDisposable
     }
 
     /// <summary>
-    /// <para lang="zh">获得当前布局 Json 字符串</para>
-    /// <para lang="en">Gets the current layout JSON string.</para>
+    /// <para lang="zh">获得 当前布局 JSON 字符串</para>
+    /// <para lang="en">Gets the current layout JSON string</para>
     /// </summary>
-    /// <returns></returns>
     public Task<string?> SaveLayout() => InvokeAsync<string?>("save", Id);
 
     private Task OnThemeChangedAsync(string themeName)
@@ -263,8 +260,8 @@ public partial class DockViewV2 : IDisposable
     }
 
     /// <summary>
-    /// <para lang="zh">标签页关闭回调方法 由 JavaScript 调用</para>
-    /// <para lang="en">Tab close callback method called by JavaScript</para>
+    /// <para lang="zh">初始化完成回调方法，由 JavaScript 调用</para>
+    /// <para lang="en">Initialization callback method called by JavaScript</para>
     /// </summary>
     [JSInvokable]
     public async Task InitializedCallbackAsync()
@@ -276,8 +273,8 @@ public partial class DockViewV2 : IDisposable
     }
 
     /// <summary>
-    /// <para lang="zh">标签页关闭回调方法 由 JavaScript 调用</para>
-    /// <para lang="en">Tab close callback method called by JavaScript</para>
+    /// <para lang="zh">标签页可见状态变更回调方法，由 JavaScript 调用</para>
+    /// <para lang="en">Tab visibility state change callback method called by JavaScript</para>
     /// </summary>
     [JSInvokable]
     public async Task PanelVisibleChangedCallbackAsync(string key, bool status)
@@ -304,8 +301,8 @@ public partial class DockViewV2 : IDisposable
     }
 
     /// <summary>
-    /// <para lang="zh">锁定回调方法 由 JavaScript 调用</para>
-    /// <para lang="en">Lock callback method called by JavaScript</para>
+    /// <para lang="zh">锁定状态变更回调方法，由 JavaScript 调用</para>
+    /// <para lang="en">Lock state change callback method called by JavaScript</para>
     /// </summary>
     [JSInvokable]
     public async Task LockChangedCallbackAsync(string[] panels, bool state)
@@ -337,10 +334,9 @@ public partial class DockViewV2 : IDisposable
     private HashSet<string> _loadTabs = new();
 
     /// <summary>
-    /// <para lang="zh">加载指定的标签页 由 JavaScript 调用</para>
-    /// <para lang="en">Loads the specified tabs called by JavaScript</para>
+    /// <para lang="zh">加载指定标签页的方法，由 JavaScript 调用</para>
+    /// <para lang="en">Method that loads the specified tabs, called by JavaScript</para>
     /// </summary>
-    /// <param name="tabs"></param>
     [JSInvokable]
     public Task LoadTabs(List<string> tabs)
     {
@@ -367,7 +363,7 @@ public partial class DockViewV2 : IDisposable
     }
 
     /// <summary>
-    /// <para lang="zh">分割器回调方法 由 JavaScript 调用</para>
+    /// <para lang="zh">分割器回调方法，由 JavaScript 调用</para>
     /// <para lang="en">Splitter callback method called by JavaScript</para>
     /// </summary>
     [JSInvokable]

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.js
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.js
@@ -33,7 +33,7 @@ export async function init(id, invoke, options) {
         invoke.invokeMethodAsync(options.splitterCallback);
     });
     dockview.on('loadTabs', tabs => {
-
+        invoke.invokeMethodAsync(options.loadTabs, tabs);
     });
 
     EventHandler.on(document, 'changed.bb.theme', updateTheme);

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.js
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.js
@@ -26,8 +26,8 @@ export async function init(id, invoke, options) {
     dockview.on('lockChanged', ({ title, isLock }) => {
         invoke.invokeMethodAsync(options.lockChangedCallback, title, isLock);
     });
-    dockview.on('panelVisibleChanged', ({ title, status }) => {
-        invoke.invokeMethodAsync(options.panelVisibleChangedCallback, title, status);
+    dockview.on('panelVisibleChanged', ({ key, status }) => {
+        invoke.invokeMethodAsync(options.panelVisibleChangedCallback, key, status);
     });
     dockview.on('groupSizeChanged', () => {
         invoke.invokeMethodAsync(options.splitterCallback);

--- a/src/components/BootstrapBlazor.DockView/Converters/DockViewComponentConverter.cs
+++ b/src/components/BootstrapBlazor.DockView/Converters/DockViewComponentConverter.cs
@@ -42,7 +42,7 @@ class DockViewComponentConverter : JsonConverter<List<DockViewComponentBase>>
             }
             else if (item is DockViewComponent contentItem)
             {
-                writer.WriteRawValue(JsonSerializer.Serialize(contentItem, options));
+                writer.WriteRawValue(JsonSerializer.Serialize(contentItem.GetState(), options));
             }
         }
         writer.WriteEndArray();

--- a/src/components/BootstrapBlazor.DockView/Converters/DockViewComponentConverter.cs
+++ b/src/components/BootstrapBlazor.DockView/Converters/DockViewComponentConverter.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// <para lang="zh">DockViewComponent 转化器</para>
+/// <para lang="zh">DockViewComponent 转换器</para>
 /// <para lang="en">DockViewComponent converter</para>
 /// </summary>
 class DockViewComponentConverter : JsonConverter<List<DockViewComponentBase>>
@@ -19,7 +19,6 @@ class DockViewComponentConverter : JsonConverter<List<DockViewComponentBase>>
     /// <param name="reader"></param>
     /// <param name="typeToConvert"></param>
     /// <param name="options"></param>
-    /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
     public override List<DockViewComponentBase>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {

--- a/src/components/BootstrapBlazor.DockView/Converters/DockViewComponentConverter.cs
+++ b/src/components/BootstrapBlazor.DockView/Converters/DockViewComponentConverter.cs
@@ -42,7 +42,7 @@ class DockViewComponentConverter : JsonConverter<List<DockViewComponentBase>>
             }
             else if (item is DockViewComponent contentItem)
             {
-                writer.WriteRawValue(JsonSerializer.Serialize(contentItem.GetState(), options));
+                writer.WriteRawValue(JsonSerializer.Serialize(contentItem, options));
             }
         }
         writer.WriteEndArray();

--- a/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
+++ b/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
@@ -32,11 +32,15 @@ class DockViewComponentState(DockViewComponent component)
     /// <para lang="zh">获得/设置 组件内容是否渲染，默认为 false</para>
     /// <para lang="en">Gets or sets whether the component is rendered. Default is false</para>
     /// </summary>
+    /// <remarks>
+    ///   <para lang="zh">组件内容是否渲染，默认为 false，只有当组件可见时并且当前状态为 Active 时才会渲染组件内容</para>
+    ///   <para lang="en">Whether the component content is rendered. Default is false. The content is only rendered when the component is visible and the current state is Active.</para>
+    /// </remarks>
     public bool Render { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 组件实例，默认为 null</para>
     /// <para lang="en">Gets or sets the component instance. Default is null</para>
     /// </summary>
-    public DockViewComponent? Component => component;
+    public DockViewComponent Component => component;
 }

--- a/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
+++ b/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
@@ -7,7 +7,7 @@ namespace BootstrapBlazor.Components;
 /// <summary>
 /// <para lang="zh">DockView 组件状态持久化类</para>
 /// </summary>
-record struct DockViewComponentState
+class DockViewComponentState
 {
     /// <summary>
     /// <para lang="zh">获得/设置 组件唯一标识值 默认 null 未设置</para>
@@ -23,4 +23,9 @@ record struct DockViewComponentState
     /// <para lang="zh">获得/设置 组件是否可见 默认 false</para>
     /// </summary>
     public bool Visible { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 组件是否渲染 默认 false</para>
+    /// </summary>
+    public bool Render { get; set; }
 }

--- a/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
+++ b/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
@@ -8,7 +8,7 @@ namespace BootstrapBlazor.Components;
 /// <para lang="zh">DockView 组件状态</para>
 /// <para lang="en">DockView component state</para>
 /// </summary>
-class DockViewComponentState
+class DockViewComponentState(DockViewComponent component)
 {
     /// <summary>
     /// <para lang="zh">获得/设置 组件唯一标识，默认为 null</para>
@@ -33,4 +33,10 @@ class DockViewComponentState
     /// <para lang="en">Gets or sets whether the component is rendered. Default is false</para>
     /// </summary>
     public bool Render { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 组件实例，默认为 null</para>
+    /// <para lang="en">Gets or sets the component instance. Default is null</para>
+    /// </summary>
+    public DockViewComponent? Component => component;
 }

--- a/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
+++ b/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
@@ -1,0 +1,26 @@
+// Copyright (c) BootstrapBlazor & Argo Zhang (argo@live.ca). All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Website: https://www.blazor.zone
+
+namespace BootstrapBlazor.Components;
+
+/// <summary>
+/// <para lang="zh">DockView 组件状态持久化类</para>
+/// </summary>
+record struct DockViewComponentState
+{
+    /// <summary>
+    /// <para lang="zh">获得/设置 组件唯一标识值 默认 null 未设置</para>
+    /// </summary>
+    public string? Key { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 组件是否锁定 默认 false</para>
+    /// </summary>
+    public bool IsLock { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 组件是否可见 默认 false</para>
+    /// </summary>
+    public bool Visible { get; set; }
+}

--- a/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
+++ b/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
@@ -5,27 +5,32 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// <para lang="zh">DockView 组件状态持久化类</para>
+/// <para lang="zh">DockView 组件状态</para>
+/// <para lang="en">DockView component state</para>
 /// </summary>
 class DockViewComponentState
 {
     /// <summary>
-    /// <para lang="zh">获得/设置 组件唯一标识值 默认 null 未设置</para>
+    /// <para lang="zh">获得/设置 组件唯一标识，默认为 null</para>
+    /// <para lang="en">Gets or sets the unique component identifier. Default is null</para>
     /// </summary>
     public string? Key { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件是否锁定 默认 false</para>
+    /// <para lang="zh">获得/设置 组件是否锁定，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the component is locked. Default is false</para>
     /// </summary>
     public bool? IsLock { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件是否可见 默认 false</para>
+    /// <para lang="zh">获得/设置 组件是否可见，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the component is visible. Default is false</para>
     /// </summary>
     public bool Visible { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件是否渲染 默认 false</para>
+    /// <para lang="zh">获得/设置 组件是否已渲染，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the component is rendered. Default is false</para>
     /// </summary>
     public bool Render { get; set; }
 }

--- a/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
+++ b/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
@@ -17,7 +17,7 @@ record struct DockViewComponentState
     /// <summary>
     /// <para lang="zh">获得/设置 组件是否锁定 默认 false</para>
     /// </summary>
-    public bool IsLock { get; set; }
+    public bool? IsLock { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 组件是否可见 默认 false</para>

--- a/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
+++ b/src/components/BootstrapBlazor.DockView/Data/DockViewComponentState.cs
@@ -23,13 +23,13 @@ class DockViewComponentState
     public bool? IsLock { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件是否可见，默认为 false</para>
-    /// <para lang="en">Gets or sets whether the component is visible. Default is false</para>
+    /// <para lang="zh">获得/设置 组件是否可见，默认为 true</para>
+    /// <para lang="en">Gets or sets whether the component is visible. Default is true</para>
     /// </summary>
-    public bool Visible { get; set; }
+    public bool Visible { get; set; } = true;
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件是否已渲染，默认为 false</para>
+    /// <para lang="zh">获得/设置 组件内容是否渲染，默认为 false</para>
     /// <para lang="en">Gets or sets whether the component is rendered. Default is false</para>
     /// </summary>
     public bool Render { get; set; }

--- a/src/components/BootstrapBlazor.DockView/Extensions/DockViewComponentStateExtensions.cs
+++ b/src/components/BootstrapBlazor.DockView/Extensions/DockViewComponentStateExtensions.cs
@@ -8,42 +8,20 @@ static class DockViewComponentStateExtensions
 {
     extension(DockViewComponentState? state)
     {
+        /// <summary>
+        /// <para lang="zh">判断组件是否需要渲染</para>
+        /// <para lang="en">Determine whether the component needs to be rendered</para>
+        /// </summary>
         public bool IsRender()
         {
+            // 如果组件 Visible false 表示组件不可见，此时 Render 也不需要渲染
             var render = false;
             if (state != null)
             {
+                // 组件必须可见并且 Active 时才需要渲染
                 render = state.Render && state.Visible;
             }
             return render;
-        }
-
-        public object? GetComponentState(DockViewComponent component)
-        {
-            if (state == null)
-            {
-                return null;
-            }
-
-            return new
-            {
-                component.Class,
-                component.Height,
-                component.Id,
-                component.IsFloating,
-                IsLock = state.IsLock,
-                component.Key,
-                component.ShowClose,
-                component.ShowFloat,
-                component.ShowLock,
-                component.ShowMaximize,
-                component.Title,
-                component.TitleClass,
-                component.TitleWidth,
-                component.Type,
-                Visible = state.Visible,
-                component.Width
-            };
         }
     }
 }

--- a/src/components/BootstrapBlazor.DockView/Extensions/DockViewComponentStateExtensions.cs
+++ b/src/components/BootstrapBlazor.DockView/Extensions/DockViewComponentStateExtensions.cs
@@ -1,0 +1,49 @@
+// Copyright (c) BootstrapBlazor & Argo Zhang (argo@live.ca). All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Website: https://www.blazor.zone
+
+namespace BootstrapBlazor.Components;
+
+static class DockViewComponentStateExtensions
+{
+    extension(DockViewComponentState? state)
+    {
+        public bool IsRender()
+        {
+            var render = false;
+            if (state != null)
+            {
+                render = state.Render && state.Visible;
+            }
+            return render;
+        }
+
+        public object? GetComponentState(DockViewComponent component)
+        {
+            if (state == null)
+            {
+                return null;
+            }
+
+            return new
+            {
+                component.Class,
+                component.Height,
+                component.Id,
+                component.IsFloating,
+                IsLock = state.IsLock,
+                component.Key,
+                component.ShowClose,
+                component.ShowFloat,
+                component.ShowLock,
+                component.ShowMaximize,
+                component.Title,
+                component.TitleClass,
+                component.TitleWidth,
+                component.Type,
+                Visible = state.Visible,
+                component.Width
+            };
+        }
+    }
+}

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -300,6 +300,12 @@
     z-index: -1 !important;
 }
 
-.dv-split-view-container.dv-vertical .dv-view:not(.visible) + .dv-view:before {
+/* .dv-split-view-container.dv-vertical .dv-view:not(.visible) + .dv-view:before {
+    height: 0;
+} */
+
+.bb-dockview .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view:not(:first-child):not(.visible):before,
+.bb-dockview .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view:first-child:not(.visible) + .dv-view.visible:before,
+.bb-dockview .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view.first-visible::before {
     height: 0;
 }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -300,6 +300,6 @@
     z-index: -1 !important;
 }
 
-.bb-dockview .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view:not(:first-child):not(.visible):before {
+.dv-split-view-container.dv-vertical .dv-view:not(.visible) + .dv-view:before {
     height: 0;
 }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -300,6 +300,6 @@
     z-index: -1 !important;
 }
 
-/* .bb-dockview .dv-view-container > .dv-view:first-child:not(.visible) + .dv-view.visible::before {
+.bb-dockview .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view:not(:first-child):not(.visible):before {
     height: 0;
-} */
+}

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -300,6 +300,6 @@
     z-index: -1 !important;
 }
 
-.bb-dockview .dv-view-container > .dv-view:first-child:not(.visible) + .dv-view.visible::before {
+/* .bb-dockview .dv-view-container > .dv-view:first-child:not(.visible) + .dv-view.visible::before {
     height: 0;
-}
+} */

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -299,3 +299,7 @@
 .bb-dockview .dv-render-overlay-float {
     z-index: -1 !important;
 }
+
+.bb-dockview .dv-view-container > .dv-view:first-child:not(.visible) + .dv-view.visible::before {
+    height: 0;
+}

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -300,10 +300,6 @@
     z-index: -1 !important;
 }
 
-/* .dv-split-view-container.dv-vertical .dv-view:not(.visible) + .dv-view:before {
-    height: 0;
-} */
-
 .bb-dockview .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view:not(:first-child):not(.visible):before,
 .bb-dockview .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view:first-child:not(.visible) + .dv-view.visible:before,
 .bb-dockview .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view.first-visible::before {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -127,6 +127,7 @@
             }
 
         .bb-dockview .dv-tab-on > .dv-default-tab-content + .dv-default-tab-action,
+        .bb-dockview .dv-tab-on > .bb-dockview-item-title + .dv-default-tab-action,
         .bb-dockview .dv-tabs-and-actions-container:has(.dv-tab-on) > .dv-right-actions-container > .bb-dockview-control-icon-close,
         .bb-dockview .dv-right-actions-container:not(.bb-show-pin) .bb-dockview-control-icon-pin,
         .bb-dockview .dv-right-actions-container:not(.bb-show-pin) .bb-dockview-control-icon-pushpin,

--- a/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/css/dockview-bb.css
@@ -1,4 +1,4 @@
-﻿@import './dockview.css';
+@import './dockview.css';
 
 .bb-dockview {
     --bb-dockview-padding: .25rem;

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -75,8 +75,18 @@ DockviewComponent.prototype.removePanel = function (...args) {
     const panel = args[0], noFiring = args[1]
     if (!panel.group.locked) {
         removePanel.apply(this, args)
-        if (!this.isClearing && noFiring!== true) {
+        if (!this.isClearing) {
             this._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
+        }
+    }
+    if (noFiring !== true) {
+        if (panel.view.content.element) {
+            if (panel.titleMenuEle) {
+                panel.view.content.element.append(panel.titleMenuEle)
+            }
+            if (this.params.template) {
+                this.params.template.append(panel.view.content.element)
+            }
         }
     }
 }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -72,10 +72,10 @@ DockviewComponent.prototype.removeGroup = function (...args) {
 
 const removePanel = DockviewComponent.prototype.removePanel
 DockviewComponent.prototype.removePanel = function (...args) {
-    const panel = args[0]
+    const panel = args[0], noFiring = args[1]
     if (!panel.group.locked) {
         removePanel.apply(this, args)
-        if (!this.isClearing) {
+        if (!this.isClearing && noFiring!== true) {
             this._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
         }
     }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -1,4 +1,4 @@
-﻿import { DockviewComponent, DockviewGroupPanel, getGridLocation, getRelativeLocation, DockviewEmitter } from "./dockview-core.esm.js"
+import { DockviewComponent, DockviewGroupPanel, getGridLocation, getRelativeLocation, DockviewEmitter } from "./dockview-core.esm.js"
 import { getConfigFromStorage, saveConfig } from "./dockview-config.js"
 import { disposeGroup, removeDrawerBtn } from "./dockview-group.js"
 
@@ -72,14 +72,14 @@ DockviewComponent.prototype.removeGroup = function (...args) {
 
 const removePanel = DockviewComponent.prototype.removePanel
 DockviewComponent.prototype.removePanel = function (...args) {
-    const panel = args[0], noFiring = args[1]
+    const panel = args[0], moveToTemplate = args[1]
     if (!panel.group.locked) {
         removePanel.apply(this, args)
         if (!this.isClearing) {
             this._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
         }
     }
-    if (noFiring !== true) {
+    if (moveToTemplate) {
         if (panel.view.content.element) {
             if (panel.titleMenuEle) {
                 panel.view.content.element.append(panel.titleMenuEle)

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -54,16 +54,6 @@ DockviewComponent.prototype.removeGroup = function(...args) {
             panel.api.close()
         })
         this.setVisible(group, false)
-
-        // let delPanelsStr = localStorage.getItem(this.params.options.localStorageKey + '-panels')
-        // let delPanels = delPanelsStr ? JSON.parse(delPanelsStr) : delPanelsStr
-        // delPanels = delPanels?.map(panel => {
-        //     if (panel.groupId == group.id) {
-        //         panel.groupInvisible = true
-        //     }
-        //     return panel
-        // })
-        // delPanels && localStorage.setItem(this.params.options.localStorageKey + '-panels', JSON.stringify(delPanels))
     }
     else if (type == 'floating') {
         removeDrawerBtn(group)
@@ -72,11 +62,10 @@ DockviewComponent.prototype.removeGroup = function(...args) {
 }
 
 const closePanel = DockviewGroupPanelModel.prototype.closePanel;
-DockviewGroupPanelModel.prototype.closePanel = function(panel) {
-    console.log(panel);
+DockviewGroupPanelModel.prototype.closePanel = function(panel, triggerVisibleChangedCallback = true) {
     if (!panel.group.locked) {
         closePanel.call(this, panel);
-        if (!this.accessor.isClearing && this.accessor.isUpdating !== true) {
+        if (triggerVisibleChangedCallback) {
             this.accessor._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
         }
     }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -76,7 +76,7 @@ DockviewComponent.prototype.removePanel = function (...args) {
     if (!panel.group.locked) {
         removePanel.apply(this, args)
         if (!this.isClearing) {
-            this._panelVisibleChanged?.fire({ title: panel.title, status: false });
+            this._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
         }
     }
 }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -1,14 +1,14 @@
-import { DockviewComponent, DockviewGroupPanel, getGridLocation, getRelativeLocation, DockviewEmitter } from "./dockview-core.esm.js"
+import { DockviewComponent, DockviewGroupPanel, DockviewGroupPanelModel, getGridLocation, getRelativeLocation, DockviewEmitter } from "./dockview-core.esm.js"
 import { getConfigFromStorage, saveConfig } from "./dockview-config.js"
 import { disposeGroup, removeDrawerBtn } from "./dockview-group.js"
 
-DockviewComponent.prototype.on = function (eventType, callback) {
+DockviewComponent.prototype.on = function(eventType, callback) {
     this['_' + eventType] = new DockviewEmitter();
     this['_' + eventType].event(callback)
 }
 
 const dispose = DockviewComponent.prototype.dispose;
-DockviewComponent.prototype.dispose = function () {
+DockviewComponent.prototype.dispose = function() {
     this.params.observer?.disconnect();
     this.groups.forEach(group => {
         if (group.mutationObserver) {
@@ -20,28 +20,29 @@ DockviewComponent.prototype.dispose = function () {
 }
 
 const groupDispose = DockviewGroupPanel.prototype.dispose
-DockviewGroupPanel.prototype.dispose = function () {
+DockviewGroupPanel.prototype.dispose = function() {
     disposeGroup(this)
     groupDispose.call(this)
 }
-DockviewGroupPanel.prototype.getParams = function () {
+DockviewGroupPanel.prototype.getParams = function() {
     return this.activePanel?.params || {}
 }
 
-DockviewGroupPanel.prototype.setParams = function (data) {
+DockviewGroupPanel.prototype.setParams = function(data) {
+    console.log('setParameter', data);
     Object.keys(data).forEach(key => {
         this.panels.forEach(panel => panel.params[key] = data[key])
     })
 }
 
-DockviewGroupPanel.prototype.removePropsOfParams = function (keys) {
+DockviewGroupPanel.prototype.removePropsOfParams = function(keys) {
     return (keys instanceof Array)
         ? keys.map(key => this.panels.forEach(panel => delete panel.params[key]))
         : typeof keys == 'string' ? this.panels.forEach(panel => delete panel.params[keys]) : false
 }
 
 const removeGroup = DockviewComponent.prototype.removeGroup
-DockviewComponent.prototype.removeGroup = function (...args) {
+DockviewComponent.prototype.removeGroup = function(...args) {
     if (this.isClearing) {
         return removeGroup.apply(this, args)
     }
@@ -70,29 +71,31 @@ DockviewComponent.prototype.removeGroup = function (...args) {
     }
 }
 
-const removePanel = DockviewComponent.prototype.removePanel
-DockviewComponent.prototype.removePanel = function (...args) {
-    const panel = args[0], moveToTemplate = args[1]
+const closePanel = DockviewGroupPanelModel.prototype.closePanel;
+DockviewGroupPanelModel.prototype.closePanel = function(panel) {
+    console.log(panel);
     if (!panel.group.locked) {
-        removePanel.apply(this, args)
-        if (!this.isClearing) {
-            this._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
+        closePanel.call(this, panel);
+        if (!this.accessor.isClearing) {
+            this.accessor._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
         }
     }
+
+    const moveToTemplate = !this.accessor.firstLoad;
     if (moveToTemplate) {
         if (panel.view.content.element) {
             if (panel.titleMenuEle) {
                 panel.view.content.element.append(panel.titleMenuEle)
             }
-            if (this.params.template) {
-                this.params.template.append(panel.view.content.element)
+            if (this.accessor.params.template) {
+                this.accessor.params.template.append(panel.view.content.element)
             }
         }
     }
 }
 
 const setVisible = DockviewComponent.prototype.setVisible
-DockviewComponent.prototype.setVisible = function (...args) {
+DockviewComponent.prototype.setVisible = function(...args) {
     setVisible.apply(this, args)
     const branch = getBranchByGroup(args[0])
     const { orientation, splitview: { sashes } } = branch

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -76,7 +76,7 @@ DockviewGroupPanelModel.prototype.closePanel = function(panel) {
     console.log(panel);
     if (!panel.group.locked) {
         closePanel.call(this, panel);
-        if (!this.accessor.isClearing) {
+        if (!this.accessor.isClearing && this.accessor.isUpdating !== true) {
             this.accessor._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
         }
     }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -62,7 +62,7 @@ DockviewComponent.prototype.removeGroup = function(...args) {
 }
 
 const closePanel = DockviewGroupPanelModel.prototype.closePanel;
-DockviewGroupPanelModel.prototype.closePanel = function(panel, triggerVisibleChangedCallback = true) {
+DockviewGroupPanelModel.prototype.closePanel = function(panel, triggerVisibleChangedCallback = true, moveToTemplate = true) {
     if (!panel.group.locked) {
         closePanel.call(this, panel);
         if (triggerVisibleChangedCallback) {
@@ -70,7 +70,6 @@ DockviewGroupPanelModel.prototype.closePanel = function(panel, triggerVisibleCha
         }
     }
 
-    const moveToTemplate = !this.accessor.firstLoad;
     if (moveToTemplate) {
         if (panel.view.content.element) {
             if (panel.titleMenuEle) {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -1,6 +1,7 @@
 import { DockviewComponent, DockviewGroupPanel, DockviewGroupPanelModel, getGridLocation, getRelativeLocation, DockviewEmitter } from "./dockview-core.esm.js"
 import { getConfigFromStorage, saveConfig } from "./dockview-config.js"
 import { disposeGroup, removeDrawerBtn } from "./dockview-group.js"
+import { markFirstVisibleElement } from "./dockview-utils.js"
 
 DockviewComponent.prototype.on = function(eventType, callback) {
     this['_' + eventType] = new DockviewEmitter();
@@ -84,7 +85,7 @@ DockviewGroupPanelModel.prototype.closePanel = function(panel, triggerVisibleCha
 
 const setVisible = DockviewComponent.prototype.setVisible
 DockviewComponent.prototype.setVisible = function(...args) {
-    setVisible.apply(this, args)
+    setVisible.apply(this, args);
     const branch = getBranchByGroup(args[0])
     const { orientation, splitview: { sashes } } = branch
 
@@ -110,6 +111,7 @@ DockviewComponent.prototype.setVisible = function(...args) {
             }
         });
     }
+    markFirstVisibleElement(args[0])
 }
 function getBranchByGroup(group) {
     const groupEle = group.element

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -1,4 +1,4 @@
-﻿import { getIcons, getIcon } from "./dockview-icon.js"
+import { getIcons, getIcon } from "./dockview-icon.js"
 import { deletePanel, findContentFromPanels, moveAlwaysRenderPanel } from "./dockview-panel.js"
 import { saveConfig } from "./dockview-config.js"
 import { observeGroup } from "./dockview-utils.js"
@@ -41,18 +41,6 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
     let { rect = {}, packup, floatType, drawer, direction = 'left' } = panel.params || {}
     if (!group) {
         group = dockview.createGroup({ id: panel.groupId })
-        // const floatingGroupPosition = isMaximized ? {
-        //     x: 0, y: 0,
-        //     width: dockview.width,
-        //     height: dockview.height
-        // } : {
-        //     x: currentPosition?.left || 0,
-        //     y: currentPosition?.top || 0,
-        //     width: currentPosition?.width,
-        //     height: currentPosition?.height
-        // }
-        // dockview.addFloatingGroup(group, floatingGroupPosition, { skipRemoveGroup: true })
-        // createGroupActions(group);
         const width = dockview.width > 500 ? 500 : (dockview.width - 10)
         const height = dockview.height > 460 ? 460 : (dockview.height - 10)
         const left = (dockview.width - width) / 2
@@ -74,23 +62,16 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         if (floatType == 'drawer') {
             setTimeout(() => createDrawerHandle(group, direction == 'right'), 0);
         }
-        // const floatingGroup = createFloatingGroup(group, floatingGroupRect)
-        const autoHideBtn = group.header.rightActionsContainer.querySelector('.bb-dockview-control-icon-autohide')
-        if (autoHideBtn) {
-            // autoHideBtn.style.display = 'none'
-        }
-
-        // saveConfig(dockview)
     }
     else {
         if (group.api.location.type === 'grid') {
             let isVisible = dockview.isVisible(group)
             if (isVisible === false) {
                 dockview.setVisible(group, true)
-                // isMaximized && group.api.maximize();
             }
         }
     }
+
     dockview.addPanel({
         id: panel.id,
         title: panel.title,
@@ -99,11 +80,10 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         position: { referenceGroup: group, index: index || 0 },
         params: { ...panel.params, rect, packup, visible: true }
     })
-    dockview.isUpdating !== true && dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
 }
 
 const addPanelWidthCreatGroup = (dockview, panel, panels) => {
-    let { position = {}, currentPosition, packupHeight, isPackup, isMaximized } = panel.params || {}
+    let { position = {}, packupHeight, isPackup, isMaximized } = panel.params || {}
     let brothers = panels.filter(p => p.params.parentId == panel.params.parentId && p.id != panel.id)
     let group, direction
     if (brothers.length > 0 && brothers[0].params.parentType == 'group') {
@@ -138,7 +118,6 @@ const addPanelWidthCreatGroup = (dockview, panel, panels) => {
     }
     if (direction) option.position.direction = direction
     dockview.addPanel(option);
-    dockview.isUpdating !== true && dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
 }
 
 const getOrientation = function (child, group) {
@@ -177,37 +156,6 @@ const createGroupActions = (group, groupType) => {
         }
     }, 0)
     addActionEvent(group, actionContainer);
-}
-const observeDisplayChange = (icon, group) => {
-    const dockview = group.api.accessor
-    const element = icon.querySelector('.dropdown-menu')
-    const mutationObserver = new MutationObserver((mutations) => {
-        mutations.forEach(mutation => {
-            if (mutation.attributeName == 'class') {
-                if(mutation.target.classList.contains('show')) {
-                    const currentPanelEle = group.activePanel.view.content.element.parentElement
-                    const childEle = currentPanelEle.children[0]
-                    group.element.querySelector('&>.dv-content-container').append(childEle)
-                    currentPanelEle.style.zIndex = -1
-                    childEle.wrapperEle = currentPanelEle
-                }
-                else {
-                    const panelEleList = [...group.element.querySelector('&>.dv-content-container').children].map(item => {
-                        const wrapperEle = item.wrapperEle
-                        delete item.wrapperEle
-                        wrapperEle.append(item)
-                        return wrapperEle
-                    })
-                    group.element.parentElement.parentElement.append(...panelEleList)
-                }
-            }
-        })
-    });
-    group.mutationObserver = mutationObserver
-    mutationObserver.observe(element, {
-        attributes: true,
-        attributeFilter: ["class"],
-    });
 }
 
 const disposeGroup = group => {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -26,14 +26,14 @@ const onAddGroup = group => {
     dockview._inited && observeGroup(group)
 }
 
-const addGroupWithPanel = (dockview, panel, localPanel, panels, index) => {
+const addGroupWithPanel = (dockview, panel, panels, index) => {
     if (panel.groupId) {
         addPanelWidthGroupId(dockview, panel, index)
     }
     else {
         addPanelWidthCreatGroup(dockview, panel, panels)
     }
-    deletePanel(dockview, localPanel)
+    deletePanel(dockview, panel)
 }
 
 const addPanelWidthGroupId = (dockview, panel, index) => {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -99,7 +99,7 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         position: { referenceGroup: group, index: index || 0 },
         params: { ...panel.params, rect, packup, visible: true }
     })
-    dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
+    dockview.isUpdating !== true && dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
 }
 
 const addPanelWidthCreatGroup = (dockview, panel, panels) => {
@@ -138,7 +138,7 @@ const addPanelWidthCreatGroup = (dockview, panel, panels) => {
     }
     if (direction) option.position.direction = direction
     dockview.addPanel(option);
-    dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
+    dockview.isUpdating !== true && dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
 }
 
 const getOrientation = function (child, group) {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -99,7 +99,7 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         position: { referenceGroup: group, index: index || 0 },
         params: { ...panel.params, rect, packup, visible: true }
     })
-    dockview._panelVisibleChanged?.fire({ title: panel.title, status: true });
+    dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
 }
 
 const addPanelWidthCreatGroup = (dockview, panel, panels) => {
@@ -138,7 +138,7 @@ const addPanelWidthCreatGroup = (dockview, panel, panels) => {
     }
     if (direction) option.position.direction = direction
     dockview.addPanel(option);
-    dockview._panelVisibleChanged?.fire({ title: panel.title, status: true });
+    dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
 }
 
 const getOrientation = function (child, group) {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -1,7 +1,7 @@
-import { getIcons, getIcon } from "./dockview-icon.js"
+﻿import { getIcons, getIcon } from "./dockview-icon.js"
 import { deletePanel, findContentFromPanels, moveAlwaysRenderPanel } from "./dockview-panel.js"
 import { saveConfig } from "./dockview-config.js"
-import { observeGroup } from "./dockview-utils.js"
+import { observeGroup, markFirstVisibleElement } from "./dockview-utils.js"
 import EventHandler from '../../BootstrapBlazor/modules/event-handler.js'
 
 const onAddGroup = group => {
@@ -20,7 +20,8 @@ const onAddGroup = group => {
         saveConfig(dockview)
     })
     group.model.contentContainer.dropTarget.onDrop(() => {
-        saveConfig(dockview)
+        saveConfig(dockview);
+        markFirstVisibleElement(group)
     })
     createGroupActions(group);
     dockview._inited && observeGroup(group)

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
@@ -84,7 +84,7 @@ const onRemovePanel = event => {
             event.view.content.element.append(event.titleMenuEle)
         }
         if (dockview.params.template) {
-            // dockview.params.template.append(event.view.content.element)
+            dockview.params.template.append(event.view.content.element)
         }
     }
 }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
@@ -11,10 +11,11 @@ const observePanelActiveChange = panel => {
     panel.api.onDidActiveChange(({ isActive }) => {
         if (isActive && !panel.group.api.isMaximized()) {
             saveConfig(panel.accessor)
-            if (panel.group.panels.length < 2) return
-            panel.group.panels.filter(p => p != panel.group.activePanel && p.renderer == 'onlyWhenVisible').forEach(p => {
-                appendTemplatePanelEle(p)
-            })
+            if (panel.group.panels.length >= 2){
+                panel.group.panels.filter(p => p != panel.group.activePanel && p.renderer == 'onlyWhenVisible').forEach(p => {
+                    appendTemplatePanelEle(p)
+                })
+            }
         }
         if (isActive && panel.group.getParams().floatType == 'drawer') {
             setDrawerTitle(panel.group)
@@ -79,14 +80,14 @@ const onRemovePanel = event => {
         })
     }
 
-    if (event.view.content.element) {
-        if (event.titleMenuEle) {
-            event.view.content.element.append(event.titleMenuEle)
-        }
-        if (dockview.params.template) {
-            dockview.params.template.append(event.view.content.element)
-        }
-    }
+    // if (event.view.content.element) {
+    //     if (event.titleMenuEle) {
+    //         event.view.content.element.append(event.titleMenuEle)
+    //     }
+    //     if (dockview.params.template) {
+    //         dockview.params.template.append(event.view.content.element)
+    //     }
+    // }
 }
 
 const appendTemplatePanelEle = (panel) => {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
@@ -26,8 +26,8 @@ const observePanelActiveChange = panel => {
     panel.api.onDidVisibilityChange(({ isVisible }) => {
         const dockview = panel.accessor;
         if (dockview.params.options.renderer === 'onlyWhenVisible' && dockview._inited && isVisible) {
-            const visiblePanels = dockview.groups.map(g => g.panels.find(p => p.params.isActive) || g.panels.find(p => p.api.isVisible))
             setTimeout(function() {
+                const visiblePanels = dockview.groups.map(g => g.panels.find(p => p.params.isActive) || g.panels.find(p => p.api.isVisible))
                 dockview._loadTabs?.fire(visiblePanels.filter(p => Boolean(p)).map(p => p.params.key));
             }, 0)
         }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -239,7 +239,7 @@ const toggleComponent = (dockview, options) => {
             let indexOfOptions = groupPanels.findIndex(p => p.params.key == panel?.params.key)
             indexOfOptions = indexOfOptions == -1 ? 0 : indexOfOptions
             const index = panel && panel.params.index
-            addGroupWithPanel(dockview, p || panel, panel, panels, index ?? indexOfOptions);
+            addGroupWithPanel(dockview, panel || p, panels, index ?? indexOfOptions);
         }
     })
     localPanels.forEach(item => {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -109,6 +109,9 @@ const initDockview = (dockview, options, template) => {
                 const visiblePanels = groups.filter(g => g.isVisible).map(g => g.panels.find(p => p.params.isActive) || g.panels.find(p => p.api.isVisible))
                 dockview._loadTabs?.fire(visiblePanels.filter(p => Boolean(p)).map(p => p.params.key));
             }
+            if (options.renderer === 'always') {
+                dockview._loadTabs?.fire(dockview.panels.map(p => p.params.key));
+            }
             const { floatingGroups } = dockview.params
             dockview.floatingGroups.forEach(fg => {
                 const { top, right, bottom, left } = floatingGroups.find(g => g.data.id == fg.group.id).position
@@ -228,29 +231,37 @@ const setWidth = (target, dockview) => {
 }
 
 const toggleComponent = (dockview, options) => {
-    const panels = getPanelsFromOptions(options).filter(p => p.params.visible)
-    const localPanels = dockview.panels
+    const optionsPanels = getPanelsFromOptions(options);
+    const panels = optionsPanels.filter(p => p.params.visible);
+    const localPanels = dockview.panels;
     panels.forEach(p => {
         const pan = findContentFromPanels(localPanels, p);
         if (pan === void 0) {
-            const panel = findContentFromPanels(dockview.params.panels, p);
-            const groupPanels = panels.filter(p1 => p1.params.parentId == p.params.parentId)
-            let indexOfOptions = groupPanels.findIndex(p => p.params.key == panel?.params.key)
-            indexOfOptions = indexOfOptions == -1 ? 0 : indexOfOptions
-            const index = panel && panel.params.index
-            addGroupWithPanel(dockview, panel || p, panels, index ?? indexOfOptions);
+            const panel = findContentFromPanels(dockview.params.panels, p) || p;
+            panel.params = { ...panel.params, ...p.params };
+            const groupPanels = panels.filter(p1 => p1.params.parentId == p.params.parentId);
+            let indexOfOptions = groupPanels.findIndex(p => p.params.key == panel?.params.key);
+            indexOfOptions = indexOfOptions == -1 ? 0 : indexOfOptions;
+            // const index = panel && panel.params.index
+            addGroupWithPanel(dockview, panel, panels, indexOfOptions);
+        }
+        else {
+            if ( pan.title !== p.title ) {
+                pan.setTitle(p.title)
+            }
+            pan._params = {
+                ...pan.params,
+                ...p.params
+            }
         }
     })
     localPanels.forEach(item => {
-        const title = panels.find(p => p.params.key == item.params.key)?.title;
-        if ( title && item.title !== title ) {
-            item.setTitle(title)
-        }
         let pan = findContentFromPanels(panels, item);
         if (pan === void 0) {
-            item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key)
-            const group = item.group
-            dockview.removePanel(item, true)
+            item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key);
+            const group = item.group;
+            const noFiring = !optionsPanels.some(p => p.params.key == item.params.key || p.id == item.id || p.title == item.title);
+            dockview.removePanel(item, noFiring)
             if (group.panels.length === 0) {
                 dockview.setVisible(group, false)
             }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -260,7 +260,8 @@ const toggleComponent = (dockview, options) => {
         if (pan === void 0) {
             item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key);
             const group = item.group;
-            const noFiring = !optionsPanels.some(p => p.params.key == item.params.key || p.id == item.id || p.title == item.title);
+            const localKeys = [...localPanels.map(p => p.params.key), ...dockview.params.panels.map(p => p.params.key)]
+            const noFiring = !(optionsPanels.length === localKeys.length && localKeys.every(key => optionsPanels.some(optionsPanel => optionsPanel.params.key === key) ));
             dockview.removePanel(item, noFiring)
             if (group.panels.length === 0) {
                 dockview.setVisible(group, false)

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -83,6 +83,9 @@ const initDockview = (dockview, options, template) => {
     })
 
     dockview.onDidLayoutFromJSON(() => {
+        dockview.groups.forEach(group => {
+            markFirstVisibleElement(group);
+        })
         const handler = setTimeout(() => {
             clearTimeout(handler);
             const panels = dockview.panels;
@@ -266,6 +269,17 @@ const toggleGroupLock = (dockview, options) => {
     dockview.groups.forEach(group => {
         toggleLock(group, group.header.rightActionsContainer, options.lock)
     })
+}
+export const markFirstVisibleElement = group => {
+    if (!group) return
+    const viewContainerEle = group.element.parentElement.parentElement;
+    const className = 'first-visible';
+    [...viewContainerEle.children].forEach(ele => {
+        if (ele.classList.contains(className)) {
+            ele.classList.remove(className)
+        }
+    })
+    viewContainerEle.querySelector('.visible')?.classList.add(className);
 }
 
 export { cerateDockview };

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -21,7 +21,6 @@ const cerateDockview = (el, options) => {
         createComponent: option => new DockviewPanelContent(option)
     });
     initDockview(dockview, options, template);
-    dockview.firstLoad = true;
     dockview.init();
     return dockview;
 }
@@ -34,7 +33,6 @@ const initDockview = (dockview, options, template) => {
         const config = getConfig(options);
         dockview.params.floatingGroups = config.floatingGroups || []
         dockview.fromJSON(config);
-        // window.dockview = dockview;
     }
 
     dockview.switchTheme = theme => {
@@ -46,7 +44,6 @@ const initDockview = (dockview, options, template) => {
     }
 
     dockview.update = options => {
-        dockview.isUpdating = true;
         if (dockview.params.options.lock !== options.lock) {
             dockview.params.options.lock = options.lock;
             toggleGroupLock(dockview, options);
@@ -61,8 +58,6 @@ const initDockview = (dockview, options, template) => {
         else {
             toggleComponent(dockview, options);
         }
-        dockview.firstLoad = false;
-        dockview.isUpdating = false;
     }
 
     dockview.reset = options => {
@@ -98,10 +93,12 @@ const initDockview = (dockview, options, template) => {
             if (options.enableLocalStorage) {
                 panels.forEach(panel => {
                     const visible = panel.params.visible
-                    if (!visible) {
+                    if (visible) {
+                        dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: true });
+                    }
+                    else {
                         panel.group.model.closePanel(panel)
                     }
-                    dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: visible });
                 })
                 delPanels.forEach(panel => {
                     dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
@@ -133,7 +130,7 @@ const initDockview = (dockview, options, template) => {
             dockview.groups.forEach(group => {
                 observeGroup(group)
             })
-            dockview.element.querySelector('&>.dv-dockview>.dv-branch-node').addEventListener('click', function (e) {
+            dockview.element.querySelector('&>.dv-dockview>.dv-branch-node').addEventListener('click', function(e) {
                 this.parentElement.querySelectorAll('&>.dv-resize-container-drawer, &>.dv-render-overlay-float-drawer').forEach(item => {
                     item.classList.remove('active')
                 })
@@ -239,7 +236,7 @@ const toggleComponent = (dockview, options) => {
             addGroupWithPanel(dockview, panel, panels, indexOfOptions);
         }
         else {
-            if ( pan.title !== p.title ) {
+            if (pan.title !== p.title) {
                 pan.setTitle(p.title)
             }
             pan._params = {
@@ -248,12 +245,17 @@ const toggleComponent = (dockview, options) => {
             }
         }
     })
+    
     localPanels.forEach(item => {
         let pan = findContentFromPanels(panels, item);
         if (pan === void 0) {
             item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key);
             const group = item.group;
-            group.model.closePanel(item, false)
+
+            const moveToTemplate = dockview.firstLoad ?? false;
+            group.model.closePanel(item, false, moveToTemplate);
+            dockview.firstLoad = true;
+
             if (group.panels.length === 0) {
                 dockview.setVisible(group, false)
             }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -60,6 +60,7 @@ const initDockview = (dockview, options, template) => {
         else {
             toggleComponent(dockview, options);
         }
+        dockview.firstLoad = false;
     }
 
     dockview.reset = options => {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -6,6 +6,7 @@ import { getConfig, reloadFromConfig, loadPanelsFromLocalstorage, saveConfig } f
 import './dockview-extensions.js'
 
 const cerateDockview = (el, options) => {
+    options.enableLocalStorage = true;
     const theme = options.theme || "dockview-theme-light";
     const template = el.querySelector('template');
     options.renderer ??= 'onlyWhenVisible'; // onlyWhenVisible | partial | always
@@ -92,16 +93,19 @@ const initDockview = (dockview, options, template) => {
             const delPanelsStr = localStorage.getItem(dockview.params.options.localStorageKey + '-panels');
             const delPanels = delPanelsStr && JSON.parse(delPanelsStr) || [];
 
-            panels.forEach(panel => {
-                const visible = panel.params.visible
-                if (!visible) {
-                    dockview.removePanel(panel)
-                }
-                dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: visible });
-            })
-            delPanels.forEach(panel => {
-                dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
-            })
+            if (options.enableLocalStorage) {
+                panels.forEach(panel => {
+                    const visible = panel.params.visible
+                    if (!visible) {
+                        dockview.removePanel(panel)
+                    }
+                    dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: visible });
+                })
+                delPanels.forEach(panel => {
+                    dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
+                })
+            }
+
             if (options.renderer === 'onlyWhenVisible') {
                 const visiblePanels = groups.filter(g => g.isVisible).map(g => g.panels.find(p => p.params.isActive) || g.panels.find(p => p.api.isVisible))
                 dockview._loadTabs?.fire(visiblePanels.filter(p => Boolean(p)).map(p => p.params.key));

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -122,19 +122,10 @@ const initDockview = (dockview, options, template) => {
                 fg.group.element.parentElement.style.inset = [top, right, bottom, left]
                     .map(item => typeof item == 'number' ? (item + 'px') : 'auto').join(' ')
 
-                // fg.overlay.onDidChangeEnd(e => {
-                //     saveConfig(dockview);
-                // })
                 observeOverlayChange(fg.overlay, fg.group)
                 const { floatType, direction } = fg.group.getParams();
                 if (floatType == 'drawer') {
                     createDrawerHandle(fg.group, direction == 'right')
-                }
-                else {
-                    const autoHideBtn = fg.group.header.rightActionsContainer.querySelector('.bb-dockview-control-icon-autohide')
-                    if (autoHideBtn) {
-                        // autoHideBtn.style.display = 'none'
-                    }
                 }
                 observeFloatingGroupLocationChange(fg.group)
             })
@@ -245,7 +236,6 @@ const toggleComponent = (dockview, options) => {
             const groupPanels = panels.filter(p1 => p1.params.parentId == p.params.parentId);
             let indexOfOptions = groupPanels.findIndex(p => p.params.key == panel?.params.key);
             indexOfOptions = indexOfOptions == -1 ? 0 : indexOfOptions;
-            // const index = panel && panel.params.index
             addGroupWithPanel(dockview, panel, panels, indexOfOptions);
         }
         else {
@@ -263,7 +253,7 @@ const toggleComponent = (dockview, options) => {
         if (pan === void 0) {
             item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key);
             const group = item.group;
-            group.model.closePanel(item)
+            group.model.closePanel(item, false)
             if (group.panels.length === 0) {
                 dockview.setVisible(group, false)
             }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -250,7 +250,7 @@ const toggleComponent = (dockview, options) => {
         let pan = findContentFromPanels(panels, item);
         if (pan === void 0) {
             item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key)
-            dockview.removePanel(item)
+            dockview.removePanel(item, true)
         }
     })
 }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -21,7 +21,7 @@ const cerateDockview = (el, options) => {
         createComponent: option => new DockviewPanelContent(option)
     });
     initDockview(dockview, options, template);
-
+    dockview.firstLoad = true;
     dockview.init();
     return dockview;
 }
@@ -260,9 +260,8 @@ const toggleComponent = (dockview, options) => {
         if (pan === void 0) {
             item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key);
             const group = item.group;
-            const localKeys = [...localPanels.map(p => p.params.key), ...dockview.params.panels.map(p => p.params.key)]
-            const noFiring = !(optionsPanels.length === localKeys.length && localKeys.every(key => optionsPanels.some(optionsPanel => optionsPanel.params.key === key) ));
-            dockview.removePanel(item, noFiring)
+            const moveToTemplate = !dockview.firstLoad;
+            dockview.removePanel(item, moveToTemplate)
             if (group.panels.length === 0) {
                 dockview.setVisible(group, false)
             }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -97,7 +97,7 @@ const initDockview = (dockview, options, template) => {
                 panels.forEach(panel => {
                     const visible = panel.params.visible
                     if (!visible) {
-                        dockview.removePanel(panel)
+                        panel.group.model.closePanel(panel)
                     }
                     dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: visible });
                 })
@@ -261,8 +261,7 @@ const toggleComponent = (dockview, options) => {
         if (pan === void 0) {
             item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key);
             const group = item.group;
-            const moveToTemplate = !dockview.firstLoad;
-            dockview.removePanel(item, moveToTemplate)
+            group.model.closePanel(item)
             if (group.panels.length === 0) {
                 dockview.setVisible(group, false)
             }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -255,9 +255,8 @@ const toggleComponent = (dockview, options) => {
             item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key);
             const group = item.group;
 
-            const moveToTemplate = dockview.firstLoad ?? false;
+            const moveToTemplate = optionsPanels.some(p => p.params.key == item.params.key);
             group.model.closePanel(item, false, moveToTemplate);
-            dockview.firstLoad = true;
 
             if (group.panels.length === 0) {
                 dockview.setVisible(group, false)

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -6,7 +6,6 @@ import { getConfig, reloadFromConfig, loadPanelsFromLocalstorage, saveConfig } f
 import './dockview-extensions.js'
 
 const cerateDockview = (el, options) => {
-    options.enableLocalStorage = true;
     const theme = options.theme || "dockview-theme-light";
     const template = el.querySelector('template');
     options.renderer ??= 'onlyWhenVisible'; // onlyWhenVisible | partial | always
@@ -250,7 +249,11 @@ const toggleComponent = (dockview, options) => {
         let pan = findContentFromPanels(panels, item);
         if (pan === void 0) {
             item.group.delPanelIndex = item.group.panels.findIndex(p => p.params.key == item.params.key)
+            const group = item.group
             dockview.removePanel(item, true)
+            if (group.panels.length === 0) {
+                dockview.setVisible(group, false)
+            }
         }
     })
 }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -97,22 +97,14 @@ const initDockview = (dockview, options, template) => {
                 if (!visible) {
                     dockview.removePanel(panel)
                 }
-                dockview._panelVisibleChanged?.fire({ title: panel.title, status: visible });
+                dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: visible });
             })
             delPanels.forEach(panel => {
-                dockview._panelVisibleChanged?.fire({ title: panel.title, status: false });
+                dockview._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
             })
-            if (options.renderer === 'always') {
-
-            }
-            else if (options.renderer === 'partial' || options.renderer === 'onlyWhenVisible') {
+            if (options.renderer === 'onlyWhenVisible') {
                 const visiblePanels = groups.filter(g => g.isVisible).map(g => g.panels.find(p => p.params.isActive) || g.panels.find(p => p.api.isVisible))
                 dockview._loadTabs?.fire(visiblePanels.filter(p => Boolean(p)).map(p => p.params.key));
-            }
-            if (options.renderer === 'partial') {
-                if (dockview.panels.length > 0) {
-                    dockview._loadTabs?.fire(dockview.panels.map(p => p.params.key));
-                }
             }
             const { floatingGroups } = dockview.params
             dockview.floatingGroups.forEach(fg => {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -46,6 +46,7 @@ const initDockview = (dockview, options, template) => {
     }
 
     dockview.update = options => {
+        dockview.isUpdating = true;
         if (dockview.params.options.lock !== options.lock) {
             dockview.params.options.lock = options.lock;
             toggleGroupLock(dockview, options);
@@ -61,6 +62,7 @@ const initDockview = (dockview, options, template) => {
             toggleComponent(dockview, options);
         }
         dockview.firstLoad = false;
+        dockview.isUpdating = false;
     }
 
     dockview.reset = options => {


### PR DESCRIPTION
## Link issues
fixes #973 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Introduce a visibility-driven rendering mode for DockViewV2 and synchronize dock panel state between Blazor components and the underlying JavaScript dockview instance.

New Features:
- Add support for the OnlyWhenVisible render mode, allowing DockView components to render content only when their panels are visible and active.
- Track per-component dock state (visibility and lock status) on the server side and expose callbacks for visibility, lock, splitter resize, and initialization events.
- Highlight the first visible dock group item in the UI to adjust splitter styling based on visibility.

Enhancements:
- Refine DockView JavaScript integration to drive tab loading, panel creation/removal, and template movement based on render mode and local storage configuration.
- Simplify render mode options by removing the Partial mode and consolidating behavior into Always and OnlyWhenVisible.
- Improve XML documentation and localization comments across DockView-related components for clearer API usage.