### PR TITLE
revert(DockView): revert implement IAsyncDisposable interface

### DIFF
--- a/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewComponent.razor.cs
@@ -191,20 +191,4 @@ public partial class DockViewComponent
     internal void SetVisible(bool visible) => Visible = visible;
 
     internal void SetLock(bool isLock) => IsLock = isLock;
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <param name="disposing"></param>
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-
-        if (OnClickTitleBarCallback != null)
-        {
-            OnClickTitleBarCallback = null;
-        }
-
-        DockView.RemoveComponentState(Key);
-    }
 }

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewTitleBar.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewTitleBar.razor.cs
@@ -10,7 +10,7 @@ namespace BootstrapBlazor.Components;
 /// <para lang="zh">DockView 标题栏组件</para>
 /// <para lang="en">DockView title bar component</para>
 /// </summary>
-public partial class DockViewTitleBar : IAsyncDisposable
+public partial class DockViewTitleBar
 {
     /// <summary>
     /// <para lang="zh">获得/设置 标题前置图标点击回调方法，默认为 null</para>
@@ -39,30 +39,5 @@ public partial class DockViewTitleBar : IAsyncDisposable
         {
             await OnClickBarCallback();
         }
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <param name="disposing"></param>
-    /// <returns></returns>
-    protected virtual ValueTask DisposeAsync(bool disposing)
-    {
-        if (disposing)
-        {
-            OnClickBarCallback = null;
-        }
-
-        return ValueTask.CompletedTask;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <returns></returns>
-    public async ValueTask DisposeAsync()
-    {
-        await DisposeAsync(true);
-        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Link issues
fixes #977 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Revert DockView async disposal and related cleanup behavior to restore the previous non-disposable components.

Enhancements:
- Remove IAsyncDisposable implementation from DockViewTitleBar and its async dispose logic.
- Remove DockViewComponent override of Dispose that cleared callbacks and component state.