### PR TITLE
feat(DockView): add OnSaveConfigCallback parameter

### DIFF
--- a/src/components/BootstrapBlazor.DockView/Components/DockViewConfig.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewConfig.cs
@@ -93,6 +93,12 @@ class DockViewConfig
     public string? SplitterCallback { get; set; }
 
     /// <summary>
+    /// <para lang="zh">获得/设置 客户端配置文件改变时回调名称</para>
+    /// <para lang="en">Gets or sets the callback name for when the client config changes</para>
+    /// </summary>
+    public string? SaveConfigCallback { get; set; }
+
+    /// <summary>
     /// <para lang="zh">获得/设置 加载标签页回调名称</para>
     /// <para lang="en">Gets or sets the callback name for loading tabs</para>
     /// </summary>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -218,27 +218,36 @@ public partial class DockViewV2
     /// </summary>
     protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetDockViewConfig());
 
-    private DockViewConfig GetDockViewConfig() => new()
+    private DockViewConfig GetDockViewConfig()
     {
-        EnableLocalStorage = IsEnableLocalStorage,
-        LocalStorageKey = LocalStorageKey,
-        IsLock = IsLock,
-        ShowLock = ShowLock,
-        IsFloating = IsFloating,
-        ShowFloat = ShowFloat,
-        ShowClose = ShowClose,
-        ShowPin = ShowPin,
-        ShowMaximize = ShowMaximize,
-        Renderer = Renderer,
-        LayoutConfig = LayoutConfig,
-        Theme = Theme.ToDescriptionString(),
-        InitializedCallback = nameof(InitializedCallbackAsync),
-        PanelVisibleChangedCallback = nameof(PanelVisibleChangedCallbackAsync),
-        LockChangedCallback = nameof(LockChangedCallbackAsync),
-        SplitterCallback = nameof(SplitterCallbackAsync),
-        Contents = _components,
-        LoadTabs = nameof(LoadTabs)
-    };
+        if (_components.Count == 0 && string.IsNullOrEmpty(LayoutConfig))
+        {
+            // 未设置布局并且未设置 LayoutConfig
+            throw new InvalidOperationException("LayoutConfig must be provided when no components are added.");
+        }
+
+        return new()
+        {
+            EnableLocalStorage = IsEnableLocalStorage,
+            LocalStorageKey = LocalStorageKey,
+            IsLock = IsLock,
+            ShowLock = ShowLock,
+            IsFloating = IsFloating,
+            ShowFloat = ShowFloat,
+            ShowClose = ShowClose,
+            ShowPin = ShowPin,
+            ShowMaximize = ShowMaximize,
+            Renderer = Renderer,
+            LayoutConfig = LayoutConfig,
+            Theme = Theme.ToDescriptionString(),
+            InitializedCallback = nameof(InitializedCallbackAsync),
+            PanelVisibleChangedCallback = nameof(PanelVisibleChangedCallbackAsync),
+            LockChangedCallback = nameof(LockChangedCallbackAsync),
+            SplitterCallback = nameof(SplitterCallbackAsync),
+            Contents = _components,
+            LoadTabs = nameof(LoadTabs)
+        };
+    }
 
     private bool IsEnableLocalStorage => EnableLocalStorage ?? _options.EnableLocalStorage ?? false;
 

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -106,6 +106,13 @@ public partial class DockViewV2
     public Func<Task>? OnInitializedCallbackAsync { get; set; }
 
     /// <summary>
+    /// <para lang="zh">获得/设置 客户端配置文件保存回调方法</para>
+    /// <para lang="en">Gets or sets the callback for when the client config is saved</para>
+    /// </summary>
+    [Parameter]
+    public Func<string, Task>? OnSaveConfigCallbackAsync { get; set; }
+
+    /// <summary>
     /// <para lang="zh">获得/设置 子组件内容</para>
     /// <para lang="en">Gets or sets the child content</para>
     /// </summary>
@@ -244,6 +251,7 @@ public partial class DockViewV2
             PanelVisibleChangedCallback = nameof(PanelVisibleChangedCallbackAsync),
             LockChangedCallback = nameof(LockChangedCallbackAsync),
             SplitterCallback = nameof(SplitterCallbackAsync),
+            SaveConfigCallback = nameof(SaveConfigCallbackAsync),
             Contents = _components,
             LoadTabs = nameof(LoadTabs)
         };
@@ -377,6 +385,25 @@ public partial class DockViewV2
         StateHasChanged();
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// <para lang="zh">保存配置回调方法，由 JavaScript 调用</para>
+    /// <para lang="en">Save configuration callback method called by JavaScript</para>
+    /// </summary>
+    /// <param name="configJsonString">
+    ///   <para lang="zh">布局配置 JSON 字符串</para>
+    ///   <para lang="en">Layout configuration JSON string</para>
+    /// </param>
+    /// <returns></returns>
+    [JSInvokable]
+    public async Task SaveConfigCallbackAsync(string configJsonString)
+    {
+        // 此处可将 configJsonString 保存到服务器中，以便下次加载时使用
+        if (OnSaveConfigCallbackAsync != null)
+        {
+            await OnSaveConfigCallbackAsync(configJsonString);
+        }
     }
 
     internal void AddComponentState(DockViewComponentState state)


### PR DESCRIPTION
## Link issues
fixes #992 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a configurable callback for saving DockView client layout configuration and enforce that a layout configuration is provided when no components are registered.

New Features:
- Expose an OnSaveConfigCallbackAsync parameter on DockViewV2 to allow consumers to handle client layout configuration persistence.
- Add a JS-invokable SaveConfigCallbackAsync entry point and corresponding SaveConfigCallback config field to integrate client-side save events with .NET callbacks.

Enhancements:
- Validate DockView initialization by requiring a LayoutConfig when no child components are added, throwing an InvalidOperationException if configuration is incomplete.