### PR TITLE
fix(Chart): can't destroy when dispose

### DIFF
--- a/src/components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
+++ b/src/components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.2</Version>
+    <Version>10.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
+++ b/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
@@ -555,12 +555,13 @@ export function toImage(id, mimeType) {
 }
 
 export function dispose(id) {
-    const chart = Data.get(id)
+    const d = Data.get(id)
     Data.remove(id)
     BootstrapBlazor.Chart.removeOptionsById(id);
 
-    if (chart) {
-        EventHandler.off(window, 'resize', chart.resizeHandler)
+    if (d) {
+        const { chart, chart: { resizeHandler } } = d;
+        EventHandler.off(window, 'resize', resizeHandler)
         chart.destroy()
     }
 }


### PR DESCRIPTION
## Link issues
fixes #997 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Ensure chart dispose uses stored instance data to remove resize handlers before destroying charts.