### PR TITLE
feat(DockView): bump version 10.0.15

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.14</Version>
+    <Version>10.0.15</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
@@ -76,8 +76,22 @@ const getConfigFromContent = options => {
 
 const mergeLayoutWithOptions = (config, options) => {
     const { layout, invisiblePanels } = config;
-    const synced = syncLayoutWithOptions(layout, options, invisiblePanels);
-    config.layout = synced;
+    // Clean invisiblePanels before merging, so sync's panelsToAdd can re-add the cleaned channels
+    const optionKeys = new Set(getPanelsFromOptions(options).map(p => p.params?.key).filter(Boolean));
+    const cleaned = (invisiblePanels || []).filter(p => {
+        if (p.params?.showClose === false) return false;   // data-driven channel wrongly registered -> drop
+        const key = p.params?.key;
+        if (key && !optionKeys.has(key)) return false;     // key no longer in options (stale after dataset switch)
+        return true;
+    });
+    // Sentinel: warn when a data-driven channel was wrongly in invisiblePanels (silent otherwise)
+    const wronglyRegistered = (invisiblePanels || []).filter(p => p.params?.showClose === false);
+    if (wronglyRegistered.length > 0) {
+        console.warn('[dockview] data-driven channel wrongly in invisiblePanels (auto-cleared):',
+            wronglyRegistered.map(p => p.params?.key), '| storage:', options.localStorageKey);
+    }
+    config.invisiblePanels = cleaned;
+    config.layout = syncLayoutWithOptions(layout, options, cleaned);
 }
 
 const getGroupIdFunc = () => {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
@@ -52,6 +52,8 @@ const moveAlwaysRenderPanel = panel => {
 
 const onRemovePanel = event => {
     const dockview = event.accessor
+    // Data-driven channels (showClose=false) must not enter invisiblePanels, else suppressed by the visible filter
+    const isDataChannel = event.params?.showClose === false;
     let invisiblePanel = {
         id: event.id,
         title: event.title,
@@ -69,7 +71,9 @@ const onRemovePanel = event => {
             index: event.group.delPanelIndex
         }
     }
-    saveInvisiblePanel(dockview, invisiblePanel)
+    if (!isDataChannel) {
+        saveInvisiblePanel(dockview, invisiblePanel)
+    }
 
     if (event.group.children) {
         event.group.children = event.group.children.filter(p => findPanel(p, event) !== null);


### PR DESCRIPTION
Channels (showClose=false, no restore entry) were wrongly registered into invisiblePanels and then permanently suppressed by toggleComponent's visible filter, causing missing channels after service restart. onRemovePanel no longer registers them; mergeLayoutWithOptions cleans such panels (and stale keys) before merge so sync can re-add them, plus a sentinel warn on wrongful registration.

## Link issues
fixes #1017 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Prevent data-driven DockView channels from being incorrectly persisted as invisible panels and ensure stale invisible panel entries are cleaned before layout sync.

Bug Fixes:
- Stop registering non-closable, data-driven channels into invisiblePanels so they are not permanently suppressed after restart.
- Clean up invalid or stale invisiblePanels entries before merging layout with options, allowing layout sync to re-add valid channels.

Enhancements:
- Log a warning when data-driven channels are wrongly found in invisiblePanels to aid diagnosing layout persistence issues.