### PR TITLE
fix(DockView): fix un-maximizing a group leaving siblings blank or stuck

### DIFF
--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
@@ -44,6 +44,7 @@ const initDockviewFromConfig = (dockview, options) => {
         try {
             mergeLayoutWithOptions(config, options);
             const { layout, invisiblePanels } = config;
+            normalizeMaximizeState(layout?.grid);
             dockview.fromJSON(layout);
             dockview.params.invisiblePanels = invisiblePanels || [];
             dockview.params.floatingGroups = layout.floatingGroups || []
@@ -198,6 +199,25 @@ const getLeafNode = (contentItem, size, boxSize, parent, panels, getGroupId, opt
     return data;
 }
 
+// Strip maximize residue: drop maximizedNode and re-show non-empty hidden grid leaves
+// (a maximized group's hidden siblings; floating placeholders are empty leaves, left as-is).
+const normalizeMaximizeState = grid => {
+    if (!grid) return;
+    delete grid.maximizedNode;
+    const walk = node => {
+        if (!node) return;
+        if (node.type === 'leaf') {
+            if (node.visible === false && node.data?.views?.length > 0) {
+                node.visible = true;
+            }
+        }
+        else if (Array.isArray(node.data)) {
+            node.data.forEach(walk);
+        }
+    };
+    walk(grid.root);
+};
+
 const saveConfig = dockview => {
     if (dockview.params.inited !== true || dockview.params.maximizing) {
         return;
@@ -207,7 +227,20 @@ const saveConfig = dockview => {
         panel.params.isActive = panel.api.isActive || panel.group.activePanel === panel
     })
 
-    const gridJson = dockview.toJSON();
+    // While maximized, toJSON()'s serialize() toggles sibling visibility once; guard it with
+    // `maximizing` so the onlyWhenVisible handler doesn't move sibling content into the template
+    // (which would blank it after exit). finally resets the flag even on throw, otherwise a stuck
+    // `maximizing` would make every later saveConfig bail at the top guard.
+    let gridJson;
+    dockview.params.maximizing = true;
+    try {
+        gridJson = dockview.toJSON();
+    }
+    finally {
+        dockview.params.maximizing = false;
+    }
+    // Maximize is transient; don't persist it.
+    normalizeMaximizeState(gridJson.grid);
     if (dockview.floatingGroups && dockview.floatingGroups.length > 0) {
         gridJson.floatingGroups.forEach((fg, index) => {
             const group = dockview.floatingGroups[index].group

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -189,9 +189,10 @@ const resetActionStates = (group, actionContainer, groupType) => {
     }
     if (showMaximize(dockview, group)) {
         actionContainer.classList.add('bb-show-maximize');
-        // if (getMaximizeState(group)) {
-        //     toggleFull(group, actionContainer, true)
-        // }
+        // restore icon state when actions are rebuilt
+        if (getMaximizeState(group)) {
+            setGroupMaximizeClass(group, true);
+        }
     }
     if (showFloat(dockview, group)) {
         actionContainer.classList.add('bb-show-float');
@@ -270,10 +271,10 @@ const addActionEvent = group => {
             group.api.accessor._lockChanged.fire({ title: group.panels.map(panel => panel.title), isLock: true });
         }
         else if (ele.classList.contains('bb-dockview-control-icon-restore')) {
-            toggleFull(group, actionContainer, true);
+            toggleFull(group, true);
         }
         else if (ele.classList.contains('bb-dockview-control-icon-full')) {
-            toggleFull(group, actionContainer, false);
+            toggleFull(group, false);
         }
         else if (ele.classList.contains('bb-dockview-control-icon-dock')) {
             dock(group);
@@ -447,22 +448,46 @@ const toggleLock = (group, actionContainer, isLock) => {
     saveConfig(group.api.accessor)
 }
 
-const toggleFull = (group, actionContainer, maximize) => {
-    group.api.accessor.params.maximizing = true;
+const setGroupMaximizeClass = (group, maximized) => {
+    const actionContainer = group.header.element.querySelector('.dv-right-actions-container');
+    actionContainer?.classList.toggle('bb-maximize', maximized);
+    group.element.parentElement?.classList.toggle('bb-maximize', maximized);
+}
+
+// Sync grid groups' bb-maximize icon from the core's authoritative maximize state.
+const onMaximizedGroupChange = event => {
+    const dockview = event.group.api.accessor;
+    dockview.groups.forEach(group => {
+        if (group.model.location.type === 'grid') {
+            setGroupMaximizeClass(group, false);
+        }
+    });
+    if (event.isMaximized) {
+        setGroupMaximizeClass(event.group, true);
+    }
+}
+
+const toggleFull = (group, maximize) => {
+    const dockview = group.api.accessor;
     const type = group.model.location.type;
-    if (type === 'grid') {
-        maximize ? group.api.exitMaximized() : group.api.maximize();
+    // `maximizing` suppresses sibling content moves while toggling; finally resets it even on throw
+    // so a stuck flag can't silently disable saveConfig.
+    dockview.params.maximizing = true;
+    try {
+        if (type === 'grid') {
+            // exitMaximizedGroup() exits unconditionally, bypassing exitMaximized()'s isMaximized()
+            // guard (after a tab switch the core's maximized instance may differ from this group).
+            // grid icon is synced by onMaximizedGroupChange.
+            maximize ? dockview.exitMaximizedGroup() : group.api.maximize();
+        }
+        else {
+            // floating maximize is pure CSS; maintain its icon here
+            maximize ? floatingExitMaximized(group) : floatingMaximize(group);
+            setGroupMaximizeClass(group, !maximize);
+        }
     }
-    else if (type === 'floating') {
-        maximize ? floatingExitMaximized(group) : floatingMaximize(group);
-    }
-    group.api.accessor.params.maximizing = false;
-    maximize ? actionContainer.classList.remove('bb-maximize') : actionContainer.classList.add('bb-maximize')
-    if (maximize) {
-        group.element.parentElement.classList.remove('bb-maximize')
-    }
-    else {
-        group.element.parentElement.classList.add('bb-maximize')
+    finally {
+        dockview.params.maximizing = false;
     }
 }
 
@@ -477,9 +502,14 @@ const float = group => {
     const floatingGroupRect = rect || {
         width, height: packup?.isPackup ? packup.height : height, position: { left, top }
     }
-    group.api.accessor.params.maximizing = true;
-    group.api.isMaximized() && group.api.exitMaximized()
-    group.api.accessor.params.maximizing = false;
+    // finally resets `maximizing` even on throw so a stuck flag can't silently disable saveConfig
+    dockview.params.maximizing = true;
+    try {
+        group.api.isMaximized() && group.api.exitMaximized()
+    }
+    finally {
+        dockview.params.maximizing = false;
+    }
     const floatingGroup = createFloatingGroup(group, floatingGroupRect)
     saveConfig(dockview)
 }
@@ -708,4 +738,4 @@ const setWidth = (observerList) => {
     })
 }
 
-export { onAddGroup, addGroupWithPanel, toggleLock, disposeGroup, observeFloatingGroupLocationChange, observeOverlayChange, createDrawerHandle, removeDrawerBtn, setDrawerTitle };
+export { onAddGroup, addGroupWithPanel, toggleLock, disposeGroup, observeFloatingGroupLocationChange, observeOverlayChange, createDrawerHandle, removeDrawerBtn, setDrawerTitle, onMaximizedGroupChange };

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -1,6 +1,6 @@
 import { DockviewComponent } from "./dockview-core.esm.js"
 import { DockviewPanelContent } from "./dockview-content.js"
-import { onAddGroup, addGroupWithPanel, toggleLock, observeFloatingGroupLocationChange, observeOverlayChange, createDrawerHandle } from "./dockview-group.js"
+import { onAddGroup, addGroupWithPanel, toggleLock, observeFloatingGroupLocationChange, observeOverlayChange, createDrawerHandle, onMaximizedGroupChange } from "./dockview-group.js"
 import { onAddPanel, onRemovePanel, getPanelsFromOptions, findContentFromPanels } from "./dockview-panel.js"
 import { initDockviewFromConfig, saveConfig } from './dockview-config.js'
 import './dockview-extensions.js'
@@ -69,6 +69,8 @@ const initDockview = (dockview, options, template) => {
     dockview.onDidAddPanel(onAddPanel);
 
     dockview.onDidAddGroup(onAddGroup);
+
+    dockview.onDidMaximizedGroupChange(onMaximizedGroupChange);
 
     dockview.onWillDragPanel(event => {
         if (event.panel.group.locked) {


### PR DESCRIPTION
- saveConfig: guard toJSON() with the maximizing flag so serialize()'s internal maximize toggle no longer moves hidden sibling content into the template (which left panels blank after exit)
- don't persist maximize state (strip maximizedNode, re-show hidden non-empty grid leaves) on save and load; self-heals corrupted layouts
- toggleFull: exit via exitMaximizedGroup() unconditionally and sync the bb-maximize icon from the core via onDidMaximizedGroupChange
- wrap maximizing flag writes in try/finally to avoid a stuck flag silently disabling saveConfig

## Link issues
fixes #1026

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix DockView maximize/unmaximize behavior so layout state is not corrupted and icons stay in sync with the core maximize state.

Bug Fixes:
- Prevent un-maximizing a maximized grid group from leaving sibling panels blank or hidden by normalizing maximize state during save and load.
- Avoid persisting transient maximize state in serialized layouts so previously corrupted configurations self-heal on reload.
- Ensure the internal maximizing flag is always cleared via try/finally so saveConfig is not silently disabled after maximize or float operations.

Enhancements:
- Sync grid groups' maximize icons from the core via a maximized-group change handler and restore icon state when actions are rebuilt.
- Unify maximize/restore handling for grid and floating groups, keeping floating maximize as a visual-only state while relying on the core for grid maximize behavior.