### PR TITLE
fix(DockView): fix group lock dropping panels and reporting wrong state

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.17</Version>
+    <Version>10.0.18</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.js
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.js
@@ -27,8 +27,8 @@ export async function init(id, invoke, options) {
     dockview.on('initialized', () => {
         invoke.invokeMethodAsync(options.initializedCallback);
     });
-    dockview.on('lockChanged', ({ title, isLock }) => {
-        invoke.invokeMethodAsync(options.lockChangedCallback, title, isLock);
+    dockview.on('lockChanged', ({ keys, isLock }) => {
+        invoke.invokeMethodAsync(options.lockChangedCallback, keys, isLock);
     });
     dockview.on('panelVisibleChanged', ({ key, status }) => {
         invoke.invokeMethodAsync(options.panelVisibleChangedCallback, key, status);

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
@@ -45,6 +45,7 @@ const initDockviewFromConfig = (dockview, options) => {
             mergeLayoutWithOptions(config, options);
             const { layout, invisiblePanels } = config;
             normalizeMaximizeState(layout?.grid);
+            pruneOrphanViews(layout);
             dockview.fromJSON(layout);
             dockview.params.invisiblePanels = invisiblePanels || [];
             dockview.params.floatingGroups = layout.floatingGroups || []
@@ -198,6 +199,42 @@ const getLeafNode = (contentItem, size, boxSize, parent, panels, getGroupId, opt
     }
     return data;
 }
+
+// Drop view ids missing from layout.panels; fromJSON throws on such orphans and reverts the
+// whole layout to empty. Only leaves/groups emptied by pruning are dropped, so already-empty
+// floating placeholders are kept and float/dock still work.
+const pruneOrphanViews = layout => {
+    if (!layout || !layout.panels) return;
+    const has = id => Object.prototype.hasOwnProperty.call(layout.panels, id);
+    // returns true if the data had views and pruning removed all of them
+    const pruneViews = data => {
+        if (!data || !Array.isArray(data.views)) return false;
+        const before = data.views.length;
+        data.views = data.views.filter(has);
+        if (!has(data.activeView)) {
+            data.activeView = data.views[0] ?? '';
+        }
+        return before > 0 && data.views.length === 0;
+    };
+    const walk = (node, parent) => {
+        if (!node) return;
+        if (node.type === 'leaf') {
+            if (pruneViews(node.data) && parent) {
+                parent.data = parent.data.filter(n => n !== node);
+            }
+        }
+        else if (node.type === 'branch' && Array.isArray(node.data)) {
+            [...node.data].forEach(child => walk(child, node));
+            if (node.data.length === 0 && parent) {
+                parent.data = parent.data.filter(n => n !== node);
+            }
+        }
+    };
+    walk(layout.grid?.root, null);
+    if (Array.isArray(layout.floatingGroups)) {
+        layout.floatingGroups = layout.floatingGroups.filter(fg => !pruneViews(fg.data));
+    }
+};
 
 // Strip maximize residue: drop maximizedNode and re-show non-empty hidden grid leaves
 // (a maximized group's hidden siblings; floating placeholders are empty leaves, left as-is).

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
@@ -355,7 +355,9 @@ const syncLayoutWithOptions = (layout, options, invisiblePanels = []) => {
                 ...localPanel.params,
                 ...optionPanel.params,
                 id: localId,
-                visible: localPanel.params.visible
+                visible: localPanel.params.visible,
+                // keep remembered lock unless backend explicitly sends one
+                isLock: optionPanel.params.isLock ?? localPanel.params.isLock
             }
         };
     }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -73,10 +73,10 @@ DockviewGroupPanelModel.prototype.closePanel = function (panel, triggerVisibleCh
         if (triggerVisibleChangedCallback) {
             this.accessor._panelVisibleChanged?.fire({ key: panel.params.key, status: false });
         }
-    }
-
-    if (moveToTemplate) {
-        movePanelContentToTemplate(panel, true);
+        // locked groups keep panels intact — guard moveToTemplate too
+        if (moveToTemplate) {
+            movePanelContentToTemplate(panel, true);
+        }
     }
 }
 

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -222,8 +222,10 @@ const getPinState = (dockview, group, groupType) => {
 }
 
 const getLockState = (dockview, group) => {
+    // group.locked (core-persisted) is the reliable truth; else fall back to isLock(3-state) / options.lock
+    if (group.locked) return true;
     const { options } = dockview.params;
-    return group.panels.every(p => p.params.isLock === null)
+    return group.panels.every(p => p.params.isLock == null)
         ? options.lock
         : group.panels.some(p => p.params.isLock === true);
 }
@@ -264,11 +266,11 @@ const addActionEvent = group => {
         const ele = e.delegateTarget;
         if (ele.classList.contains('bb-dockview-control-icon-lock')) {
             toggleLock(group, actionContainer, false);
-            group.api.accessor._lockChanged.fire({ title: group.panels.map(panel => panel.title), isLock: false });
+            group.api.accessor._lockChanged.fire({ keys: group.panels.map(panel => panel.params.key), isLock: false });
         }
         else if (ele.classList.contains('bb-dockview-control-icon-unlock')) {
             toggleLock(group, actionContainer, true);
-            group.api.accessor._lockChanged.fire({ title: group.panels.map(panel => panel.title), isLock: true });
+            group.api.accessor._lockChanged.fire({ keys: group.panels.map(panel => panel.params.key), isLock: true });
         }
         else if (ele.classList.contains('bb-dockview-control-icon-restore')) {
             toggleFull(group, true);


### PR DESCRIPTION
### Issues
close #1032 

Fixes a few DockView group-lock issues, plus a layout-restore robustness fix.

### Group lock
- Locked groups no longer lose their panels — `moveToTemplate` is now guarded so it only runs on unlocked groups.
- `lockChanged` now reports panel **keys** instead of titles, so callers can reliably map panels back.
- `getLockState` treats `group.locked` (core-persisted) as the source of truth, falling back to the per-panel 3-state `isLock` / `options.lock`.
- Layout sync keeps a remembered `isLock` unless the backend explicitly sends one.

### Layout restore
- Prune invalid panel IDs on layout restore, avoiding an empty view when deserialization hits a stale/invalid ID.

## Summary by Sourcery

Improve DockView group lock behavior and make layout restoration more robust against invalid panel references.

Bug Fixes:
- Prevent locked groups from dropping panel content when panels are closed or templates are applied.
- Ensure lock change notifications report panel keys instead of titles for reliable identification.
- Use the group's persisted lock state as the primary source of truth when determining lock status.
- Preserve remembered panel lock flags during layout synchronization unless the backend explicitly overrides them.
- Prune orphaned view IDs from layouts before deserialization to avoid empty views when stale panel IDs are present.