### PR TITLE
fix(UniverSheet): drawing edit/delete popup menu no longer disappears after batch print/export

### DIFF
--- a/src/components/BootstrapBlazor.UniverSheet/BootstrapBlazor.UniverSheet.csproj
+++ b/src/components/BootstrapBlazor.UniverSheet/BootstrapBlazor.UniverSheet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.13</Version>
+    <Version>10.0.14</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Issues
close #1033 

Fixes the drawing **edit/delete** popup menu disappearing after a batch print/export —
it no longer shows up when selecting a plot/image until a page refresh.
