### PR TITLE
fix(DockView): the width of the left and right layout panels is divided equally

### DIFF
--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-config.js
@@ -260,6 +260,13 @@ const saveConfig = dockview => {
         return;
     }
 
+    // Don't persist a collapsed/unmeasured layout: while collapsed toJSON() serializes size:100, which
+    // makes the even-split sticky across refreshes. Real layouts are measured (width>0), so this only
+    // drops a degenerate save the next change re-saves.
+    if (!dockview.width || !dockview.height) {
+        return;
+    }
+
     dockview.panels.forEach(panel => {
         panel.params.isActive = panel.api.isActive || panel.group.activePanel === panel
     })

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -68,7 +68,7 @@ DockviewComponent.prototype.removeGroup = function (...args) {
 
 const closePanel = DockviewGroupPanelModel.prototype.closePanel;
 DockviewGroupPanelModel.prototype.closePanel = function (panel, triggerVisibleChangedCallback = true, moveToTemplate = true) {
-    if (!panel.group.locked) {
+    if (!panel.group?.locked) {
         closePanel.call(this, panel);
         if (triggerVisibleChangedCallback) {
             this.accessor._panelVisibleChanged?.fire({ key: panel.params.key, status: false });

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -659,7 +659,7 @@ const down = (group, actionContainer) => {
     saveConfig(group.api.accessor)
 }
 
-close = group => {
+const close = group => {
     if (!group.locked) {
         group.api.close()
     }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -20,8 +20,26 @@ const cerateDockview = (el, options) => {
         disableTabsOverflowList: true,
         createComponent: option => new DockviewPanelContent(option)
     });
+    guardCollapsedSaveProportions(dockview);
     initDockview(dockview, options, template);
     return dockview;
+}
+
+// Fix "groups evenly split after refresh": while collapsed (size 0) skip overwriting existing
+// proportions, else saveProportions freezes the collapsed equal-minimums as the split. _proportions is
+// undefined only on the first deserialize save — let that through. Upstream fix: add `size > 0` to
+// dockview-core's Splitview.saveProportions, then drop this patch.
+const guardCollapsedSaveProportions = dockview => {
+    const splitview = dockview.gridview?.root?.splitview;
+    if (!splitview) return;
+    const proto = Object.getPrototypeOf(splitview);
+    if (proto.__bbCollapseGuard) return;          // Splitview.prototype is shared by all instances; patch once
+    proto.__bbCollapseGuard = true;
+    const original = proto.saveProportions;
+    proto.saveProportions = function () {
+        if (this.size === 0 && this._proportions) return;
+        original.call(this);
+    };
 }
 
 const initDockview = (dockview, options, template) => {


### PR DESCRIPTION
## Link issues
fixes #1039 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Guard DockView layout persistence and panel closing against collapsed or locked states to prevent incorrect equal-width splits and errors.

Bug Fixes:
- Prevent collapsed DockView layouts from overwriting existing panel proportions so previously saved widths are preserved.
- Skip saving DockView configuration when the layout has no measurable width or height to avoid persisting invalid even-split state.
- Avoid errors when closing a panel whose group reference may be undefined by safely checking the locked flag.