### PR TITLE
feat(DockView): make IsLock parameter work event set ShowLock to false

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.18</Version>
+    <Version>10.0.19</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -175,7 +175,6 @@ const disposeGroup = group => {
 
 const resetActionStates = (group, actionContainer, groupType) => {
     const dockview = group.api.accessor;
-    // bb-show-lock only gates the button; apply the lock STATE regardless so a locked group stays locked when showLock=false.
     if (showLock(dockview, group)) {
         actionContainer.classList.add('bb-show-lock');
     }
@@ -190,7 +189,6 @@ const resetActionStates = (group, actionContainer, groupType) => {
     }
     if (showMaximize(dockview, group)) {
         actionContainer.classList.add('bb-show-maximize');
-        // restore icon state when actions are rebuilt
         if (getMaximizeState(group)) {
             setGroupMaximizeClass(group, true);
         }
@@ -223,7 +221,6 @@ const getPinState = (dockview, group, groupType) => {
 }
 
 const getLockState = (dockview, group) => {
-    // group.locked (core-persisted) is the reliable truth; else fall back to isLock(3-state) / options.lock
     if (group.locked) return true;
     const { options } = dockview.params;
     return group.panels.every(p => p.params.isLock == null)
@@ -316,7 +313,6 @@ const autoHide = group => {
     }
     if (type == 'grid') {
         if (!canFloat(group)) return;
-        // 1、点击图标创建浮动窗口并隐藏
         const { drawer = { width: 300, visible: true } } = group.getParams()
 
         const left = getOffsetFromDockview(group.element)
@@ -448,7 +444,6 @@ const toggleLock = (group, actionContainer, isLock, persist = true) => {
     else {
         actionContainer.classList.remove('bb-lock')
     }
-    // persist=false: init-time restore renders the lock without saving; real changes (click / options.lock) keep the default.
     if (persist) {
         saveConfig(group.api.accessor)
     }
@@ -460,7 +455,6 @@ const setGroupMaximizeClass = (group, maximized) => {
     group.element.parentElement?.classList.toggle('bb-maximize', maximized);
 }
 
-// Sync grid groups' bb-maximize icon from the core's authoritative maximize state.
 const onMaximizedGroupChange = event => {
     const dockview = event.group.api.accessor;
     dockview.groups.forEach(group => {
@@ -476,18 +470,12 @@ const onMaximizedGroupChange = event => {
 const toggleFull = (group, maximize) => {
     const dockview = group.api.accessor;
     const type = group.model.location.type;
-    // `maximizing` suppresses sibling content moves while toggling; finally resets it even on throw
-    // so a stuck flag can't silently disable saveConfig.
     dockview.params.maximizing = true;
     try {
         if (type === 'grid') {
-            // exitMaximizedGroup() exits unconditionally, bypassing exitMaximized()'s isMaximized()
-            // guard (after a tab switch the core's maximized instance may differ from this group).
-            // grid icon is synced by onMaximizedGroupChange.
             maximize ? dockview.exitMaximizedGroup() : group.api.maximize();
         }
         else {
-            // floating maximize is pure CSS; maintain its icon here
             maximize ? floatingExitMaximized(group) : floatingMaximize(group);
             setGroupMaximizeClass(group, !maximize);
         }
@@ -508,7 +496,6 @@ const float = group => {
     const floatingGroupRect = rect || {
         width, height: packup?.isPackup ? packup.height : height, position: { left, top }
     }
-    // finally resets `maximizing` even on throw so a stuck flag can't silently disable saveConfig
     dockview.params.maximizing = true;
     try {
         group.api.isMaximized() && group.api.exitMaximized()

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -175,11 +175,12 @@ const disposeGroup = group => {
 
 const resetActionStates = (group, actionContainer, groupType) => {
     const dockview = group.api.accessor;
+    // bb-show-lock only gates the button; apply the lock STATE regardless so a locked group stays locked when showLock=false.
     if (showLock(dockview, group)) {
         actionContainer.classList.add('bb-show-lock');
-        if (getLockState(dockview, group)) {
-            toggleLock(group, actionContainer, true)
-        }
+    }
+    if (getLockState(dockview, group)) {
+        toggleLock(group, actionContainer, true, false)
     }
     if (showPin(dockview, group) && showFloat(dockview, group)) {
         actionContainer.classList.add('bb-show-pin');
@@ -438,7 +439,7 @@ const removeActionEvent = group => {
     EventHandler.off(actionContainer, 'click', '.bb-dockview-control-icon');
 }
 
-const toggleLock = (group, actionContainer, isLock) => {
+const toggleLock = (group, actionContainer, isLock, persist = true) => {
     group.locked = isLock ? 'no-drop-target' : isLock
     group.panels.forEach(panel => panel.params.isLock = isLock);
     if (isLock) {
@@ -447,7 +448,10 @@ const toggleLock = (group, actionContainer, isLock) => {
     else {
         actionContainer.classList.remove('bb-lock')
     }
-    saveConfig(group.api.accessor)
+    // persist=false: init-time restore renders the lock without saving; real changes (click / options.lock) keep the default.
+    if (persist) {
+        saveConfig(group.api.accessor)
+    }
 }
 
 const setGroupMaximizeClass = (group, maximized) => {


### PR DESCRIPTION
## Issues
close #1042 

## Problem
When `ShowLock` is false (the lock toggle button is hidden), a group that is
configured as locked — via `options.lock`, a panel's `isLock`, or a restored
`locked` layout — is not actually locked on init. `group.locked` is never set,
so the group stays draggable/closable.

## Cause
`resetActionStates` coupled "show the lock button" with "apply the lock state":
the `toggleLock(...)` call lived inside `if (showLock(group))`, so when showLock
was false the whole block — including the state application — was skipped.

## Fix
- Decouple the two. `bb-show-lock` (button visibility) is still gated on
  `showLock`, but the lock STATE is now applied whenever `getLockState(group)`
  is true, regardless of showLock. The CSS already separates `bb-show-lock`
  (toggle button) from `bb-lock` (locked appearance), so this renders correctly:
  no toggle button, but the group is locked (drag/drop/close disabled).
- Add a `persist` flag to `toggleLock`. Init-time restore (`resetActionStates`)
  renders the lock without writing it back to storage; real changes (user click
  or `options.lock` change) keep the default and persist as before.

Only groups explicitly configured as locked are affected; unlocked groups and
all `showLock=true` paths are unchanged.

## Summary by Sourcery

Ensure dockview groups correctly apply and restore their locked state independently of the lock button’s visibility.

Bug Fixes:
- Apply the configured locked state to dockview groups on initialization even when the lock toggle button is hidden.

Enhancements:
- Add a non-persisting initialization path to the lock toggling logic to avoid saving configuration when merely restoring state.