### PR TITLE
fix(DockView): keep active panel on becoming visible; only re-pick the tab on a real shrink

### DIFF
--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -201,8 +201,21 @@ const setWidth = (target, dockview) => {
     let dropdown = header.querySelector('.dv-right-actions-container>.dropdown')
     if (!dropdown) return
     let dropMenu = dropdown.querySelector('.dropdown-menu')
+    // `shrinking` (a strict width drop) gates the active-panel switch below — it must NOT fire during the
+    // transient expand a group goes through when a hidden view becomes visible (would switch + blank it).
+    const group = dockview.params.inited ? dockview.groups.find(g => g.element === header.parentElement) : null
+    const shrinking = group && group._lastHeaderWidth !== undefined && header.offsetWidth < group._lastHeaderWidth
+    if (group) group._lastHeaderWidth = header.offsetWidth
+
     if (voidWidth === 0) {
         if (tabsContainer.children.length <= 1) return
+        // On shrink, if the active tab would overflow, switch to the first panel before tucking it away.
+        if (shrinking) {
+            const activeTab = tabsContainer.querySelector('.dv-tab.dv-active-tab')
+            if (activeTab && activeTab.offsetLeft + activeTab.offsetWidth > tabsContainer.offsetWidth) {
+                group.panels[0]?.api.setActive()
+            }
+        }
         const tabs = tabsContainer.querySelectorAll('.dv-tab')
         for (let i = tabs.length - 1; i >= 0; i--) {
             const lastTab = tabs[i]
@@ -227,9 +240,9 @@ const setWidth = (target, dockview) => {
             }
         }
     }
-    if (dockview.params.inited && [...tabsContainer.children].every(tab => tab.classList.contains('dv-inactive-tab'))) {
-        const group = dockview.groups.find(g => g.element === header.parentElement)
-        group.panels[0] && group.panels[0].api.setActive()
+    // Fallback: keep an active panel when the group has none (e.g. the active one was closed).
+    if (group && !group.activePanel) {
+        group.panels[0]?.api.setActive()
     }
 }
 


### PR DESCRIPTION
## Problem
In a group with multiple panels, activate a non-first panel, switch to another
view (so this DockView's container becomes hidden), refresh, then switch back:
the group's active panel resets to the first one and its content goes blank (the
tab titles remain). Clicking any tab restores it.

## Cause
`setWidth` (the tab-overflow handler driven by a `ResizeObserver`) ended with a
fallback that force-activated `group.panels[0]` whenever the visible tab strip had
no active tab (`[...tabsContainer.children].every(t => …'dv-inactive-tab')`). When
a hidden view becomes visible after a refresh, the group's container expands from
collapsed → full, briefly passing through narrow widths where the active tab
overflows into the dropdown — so the strip momentarily reads "all inactive". That
wrongly switched the active panel to the first one, and the active-state churn
blanked the `onlyWhenVisible` content.

## Fix
- Replace the DOM-class check with a model check: only auto-activate the first
  panel when the group genuinely has no active panel (`!group.activePanel`).
- Keep the original intent (a visible active tab when the active one overflows),
  but gate it on a real shrink — track header width per group and act only when it
  strictly decreases, so the transient expand on becoming visible never triggers
  it. On a real shrink, switch the active panel before the overflowing active tab
  is tucked into the dropdown.

The overflow/dropdown logic itself is unchanged. As a side effect, showing a panel
or clicking a dropdown tab now keeps that panel active instead of snapping to the
first one.

## Summary by Sourcery

Ensure DockView tab groups retain their active panel when views become visible and only reselect the first tab on genuine header shrink events.

Bug Fixes:
- Prevent active panels from resetting to the first panel when a hidden DockView becomes visible after refresh or view switches.

Enhancements:
- Track per-group header width to detect real shrink events and switch active panels only when an active tab would overflow.
- Replace DOM-based active-tab detection with a model-based fallback that activates the first panel only when the group truly has no active panel.