### PR TITLE
fix(DockView): stop sibling blanking on any exit-maximize

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.19</Version>
+    <Version>10.0.20</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -21,8 +21,28 @@ const cerateDockview = (el, options) => {
         createComponent: option => new DockviewPanelContent(option)
     });
     guardCollapsedSaveProportions(dockview);
+    guardMaximizeExit(dockview);
     initDockview(dockview, options, template);
     return dockview;
+}
+
+// Carry the `maximizing` flag on EVERY exit-maximize, not just the toggle button: the core also exits
+// maximize when a group is removed/hidden/moved/added, and without the flag the restored siblings blank.
+const guardMaximizeExit = dockview => {
+    const gridview = dockview.gridview;
+    if (!gridview) return;
+    const proto = Object.getPrototypeOf(gridview);
+    if (proto.__bbMaximizeExitGuard) return;
+    proto.__bbMaximizeExitGuard = true;
+    const original = proto.exitMaximizedView;
+    proto.exitMaximizedView = function () {
+        const dv = this._maximizedNode?.leaf?.view?.api?.accessor;
+        if (!dv) return original.call(this);
+        const prev = dv.params.maximizing;
+        dv.params.maximizing = true;
+        try { return original.call(this); }
+        finally { dv.params.maximizing = prev; }
+    };
 }
 
 // Fix "groups evenly split after refresh": while collapsed (size 0) skip overwriting existing

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-utils.js
@@ -201,8 +201,21 @@ const setWidth = (target, dockview) => {
     let dropdown = header.querySelector('.dv-right-actions-container>.dropdown')
     if (!dropdown) return
     let dropMenu = dropdown.querySelector('.dropdown-menu')
+    // `shrinking` (a strict width drop) gates the active-panel switch below — it must NOT fire during the
+    // transient expand a group goes through when a hidden view becomes visible (would switch + blank it).
+    const group = dockview.params.inited ? dockview.groups.find(g => g.element === header.parentElement) : null
+    const shrinking = group && group._lastHeaderWidth !== undefined && header.offsetWidth < group._lastHeaderWidth
+    if (group) group._lastHeaderWidth = header.offsetWidth
+
     if (voidWidth === 0) {
         if (tabsContainer.children.length <= 1) return
+        // On shrink, if the active tab would overflow, switch to the first panel before tucking it away.
+        if (shrinking) {
+            const activeTab = tabsContainer.querySelector('.dv-tab.dv-active-tab')
+            if (activeTab && activeTab.offsetLeft + activeTab.offsetWidth > tabsContainer.offsetWidth) {
+                group.panels[0]?.api.setActive()
+            }
+        }
         const tabs = tabsContainer.querySelectorAll('.dv-tab')
         for (let i = tabs.length - 1; i >= 0; i--) {
             const lastTab = tabs[i]
@@ -227,9 +240,9 @@ const setWidth = (target, dockview) => {
             }
         }
     }
-    if (dockview.params.inited && [...tabsContainer.children].every(tab => tab.classList.contains('dv-inactive-tab'))) {
-        const group = dockview.groups.find(g => g.element === header.parentElement)
-        group.panels[0] && group.panels[0].api.setActive()
+    // Fallback: keep an active panel when the group has none (e.g. the active one was closed).
+    if (group && !group.activePanel) {
+        group.panels[0]?.api.setActive()
     }
 }
 


### PR DESCRIPTION
## Issues
close #1045 

Two fixes around the `onlyWhenVisible` renderer and visibility transitions.

## 1. Active panel resets to the first / blanks after becoming visible
**Problem:** Activate a non-first panel in a group, switch to another view (so this
DockView's container is hidden), refresh, then switch back — the group's active
panel snaps to the first one and its content goes blank (tab titles remain).

**Cause:** `setWidth`'s tab-overflow fallback force-activated `group.panels[0]`
whenever the visible tab strip had no active tab. On becoming visible after a
hidden init the group expands through narrow widths and transiently overflows the
active tab into the dropdown → reads as "no active tab" → wrong switch + churn.

**Fix:** Only re-pick the active tab on a real shrink (header width strictly drops,
never the transient expand), switching before the active tab is tucked away. The
remaining fallback fires only when the group genuinely has no active panel.

## 2. Blank DockView when a group is removed/moved/added/hidden while maximized
**Problem:** With a grid group maximized, closing all its panels (or otherwise
removing/moving/adding/hiding a group) leaves the whole DockView blank.

**Cause:** The core exits maximize on its own for those operations
(`gridview.removeView/setViewVisible/moveView/addView`), but without the
`maximizing` flag the `onlyWhenVisible` handler moves the restored siblings'
content into the template → blank. Earlier fixes (e.g. #1025) only set the flag on
the toggle-button and save paths.

**Fix:** A single guard wraps the core's `exitMaximizedView` so every exit-maximize
carries the `maximizing` flag, covering all paths at once.

## Summary by Sourcery

Guard DockView maximize exits and refine active-panel selection during tab overflow handling to prevent panels and views from becoming blank after visibility or layout changes.

Bug Fixes:
- Ensure exiting a maximized grid view always carries the maximizing flag so sibling groups restore their content instead of rendering blank when groups are added, removed, moved, or hidden.
- Adjust tab overflow handling to only reselect the first panel on genuine header width shrink and when a group has no active panel, preventing active panels from resetting or going blank after visibility transitions.