### PR TITLE
fix(DockView): correctness fixes for group delete/re-insert, float and dock-back

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.20</Version>
+    <Version>10.0.21</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-extensions.js
@@ -62,7 +62,12 @@ DockviewComponent.prototype.removeGroup = function (...args) {
     }
     else if (type == 'floating') {
         removeDrawerBtn(group)
-        return removeGroup.apply(this, args)
+        // Close panels (like the grid path) so each fires _panelVisibleChanged; the last close re-enters empty and removes the group.
+        const panels = [...group.panels]
+        if (panels.length === 0) {
+            return removeGroup.apply(this, args)
+        }
+        panels.forEach(panel => panel.api.close())
     }
 }
 

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -92,8 +92,7 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
 
     // Placeholder deferred its action states while empty (see resetActionStates); re-render now it has a panel.
     if (reusedEmptyGroup && group.api.location.type === 'grid') {
-        const actionContainer = group.header.element.querySelector('.dv-right-actions-container');
-        if (actionContainer) resetActionStates(group, actionContainer);
+        reRenderActionStates(group);
     }
 }
 
@@ -219,6 +218,12 @@ const resetActionStates = (group, actionContainer, groupType) => {
     if (showUp(group) && !getUpState(group)) {
         actionContainer.classList.add('bb-up')
     }
+}
+
+// Re-render action buttons after an empty placeholder gains a panel (its actions were deferred while empty).
+const reRenderActionStates = group => {
+    const actionContainer = group.header.element.querySelector('.dv-right-actions-container');
+    if (actionContainer) resetActionStates(group, actionContainer);
 }
 
 const showLock = (dockview, group) => {
@@ -638,6 +643,8 @@ const dock = (group, floatType) => {
         from: { group: group },
         to: { group: originGroup, position: 'center' }
     })
+    // originGroup was an empty placeholder while floated; its deferred action buttons need re-rendering now it is filled.
+    reRenderActionStates(originGroup)
     saveConfig(dockview)
 }
 

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -39,6 +39,8 @@ const addGroupWithPanel = (dockview, panel, panels, index) => {
 
 const addPanelWidthGroupId = (dockview, panel, index) => {
     let group = dockview.api.getGroup(panel.groupId)
+    // Empty pre-existing group = deleted-side placeholder (deferred actions + collapsed branch); a populated one is healthy.
+    const reusedEmptyGroup = !!group && group.panels.length === 0;
     let { rect = {}, packup, floatType, drawer, direction = 'left' } = panel.params || {}
     if (!group) {
         group = dockview.createGroup({ id: panel.groupId })
@@ -73,6 +75,10 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         }
     }
 
+    // Placeholder branch collapsed to width 0 in the saved layout; restore the pre-delete width (currentPosition)
+    // via initialWidth → setSize, else it re-shows at min ~100.
+    const restoreWidth = reusedEmptyGroup && group.api.location.type === 'grid'
+        ? panel.params?.currentPosition?.width : undefined;
     dockview.addPanel({
         id: panel.id,
         title: panel.title,
@@ -80,8 +86,15 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         renderer: panel.renderer,
         component: panel.component,
         position: { referenceGroup: group, index: index || 0 },
+        initialWidth: restoreWidth > 0 ? restoreWidth : undefined,
         params: { ...panel.params, rect, packup, visible: true }
     })
+
+    // Placeholder deferred its action states while empty (see resetActionStates); re-render now it has a panel.
+    if (reusedEmptyGroup && group.api.location.type === 'grid') {
+        const actionContainer = group.header.element.querySelector('.dv-right-actions-container');
+        if (actionContainer) resetActionStates(group, actionContainer);
+    }
 }
 
 const addPanelWidthCreatGroup = (dockview, panel, panels) => {
@@ -175,6 +188,10 @@ const disposeGroup = group => {
 
 const resetActionStates = (group, actionContainer, groupType) => {
     const dockview = group.api.accessor;
+    // Empty group: `[].every()` is vacuously true so every show*() falls back to options defaults, wrongly showing
+    // buttons that stick once re-filled. Defer until it has panels (re-rendered on insert in addPanelWidthGroupId).
+    if (group.panels.length === 0) return;
+    // bb-show-lock only gates the button; apply the lock STATE regardless so a locked group stays locked when showLock=false.
     if (showLock(dockview, group)) {
         actionContainer.classList.add('bb-show-lock');
     }

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -41,14 +41,18 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
     let group = dockview.api.getGroup(panel.groupId)
     // Empty pre-existing group = deleted-side placeholder (deferred actions + collapsed branch); a populated one is healthy.
     const reusedEmptyGroup = !!group && group.panels.length === 0;
-    let { rect = {}, packup, floatType, drawer, direction = 'left' } = panel.params || {}
+    const isNewFloatingGroup = !group;
+    let { rect = {}, packup, floatType, drawer, direction = 'left', currentPosition } = panel.params || {}
     if (!group) {
         group = dockview.createGroup({ id: panel.groupId })
         const width = dockview.width > 500 ? 500 : (dockview.width - 10)
         const height = dockview.height > 460 ? 460 : (dockview.height - 10)
         const left = (dockview.width - width) / 2
         const top = (dockview.height - height) / 2
-        let floatingGroupRect = rect || {
+        // Prefer currentPosition (saved on hide) over rect (only refreshed on un-float) to keep last size & position.
+        let floatingGroupRect = (currentPosition?.width > 0
+            ? { width: currentPosition.width, height: currentPosition.height, position: { top: currentPosition.top, left: currentPosition.left } }
+            : rect) || {
             width, height: packup?.isPackup ? packup.height : height, position: { left, top }
         }
         if (floatType == 'drawer') {
@@ -89,6 +93,11 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         initialWidth: restoreWidth > 0 ? restoreWidth : undefined,
         params: { ...panel.params, rect, packup, visible: true }
     })
+
+    // addPanel is inactive; activate so a freshly created floating group isn't blank.
+    if (isNewFloatingGroup) {
+        group.panels.find(p => p.id === panel.id)?.api.setActive();
+    }
 
     // Placeholder deferred its action states while empty (see resetActionStates); re-render now it has a panel.
     if (reusedEmptyGroup && group.api.location.type === 'grid') {

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -39,6 +39,11 @@ const addGroupWithPanel = (dockview, panel, panels, index) => {
 
 const addPanelWidthGroupId = (dockview, panel, index) => {
     let group = dockview.api.getGroup(panel.groupId)
+    // Group is floated: this grid entry is a hidden placeholder; route the re-opened panel into the floating counterpart.
+    if (group && group.panels.length === 0 && group.api.location.type === 'grid') {
+        const floated = dockview.api.getGroup(getFloatingId(group.id))
+        if (floated?.api.location.type === 'floating') group = floated
+    }
     // Empty pre-existing group = deleted-side placeholder (deferred actions + collapsed branch); a populated one is healthy.
     const reusedEmptyGroup = !!group && group.panels.length === 0;
     const isNewFloatingGroup = !group;

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -102,6 +102,8 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
     // Placeholder deferred its action states while empty (see resetActionStates); re-render now it has a panel.
     if (reusedEmptyGroup && group.api.location.type === 'grid') {
         reRenderActionStates(group);
+        // initialWidth left a _pendingSize; clear it so a later setVisible(true) (float->dock) won't replay this stale width.
+        if (restoreWidth > 0) group.api._pendingSize = undefined;
     }
 }
 

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -39,10 +39,11 @@ const addGroupWithPanel = (dockview, panel, panels, index) => {
 
 const addPanelWidthGroupId = (dockview, panel, index) => {
     let group = dockview.api.getGroup(panel.groupId)
-    // Group is floated: this grid entry is a hidden placeholder; route the re-opened panel into the floating counterpart.
-    if (group && group.panels.length === 0 && group.api.location.type === 'grid') {
-        const floated = dockview.api.getGroup(getFloatingId(group.id))
-        if (floated?.api.location.type === 'floating') group = floated
+    // The group may have moved (floated/docked) since this panel was closed; getFloatingId toggles its grid<->floating
+    // id. If our entry is empty/gone but the counterpart holds the panels, route there so the panel rejoins the group.
+    if (!group || group.panels.length === 0) {
+        const counterpart = dockview.api.getGroup(getFloatingId(panel.groupId))
+        if (counterpart && counterpart.panels.length > 0) group = counterpart
     }
     // Empty pre-existing group = deleted-side placeholder (deferred actions + collapsed branch); a populated one is healthy.
     const reusedEmptyGroup = !!group && group.panels.length === 0;

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
@@ -65,8 +65,9 @@ const onRemovePanel = event => {
             currentPosition: {
                 width: event.group.element.parentElement.offsetWidth,
                 height: event.group.element.parentElement.offsetHeight,
-                top: parseFloat(event.group.element.parentElement.style.top || 0),
-                left: parseFloat(event.group.element.parentElement.style.left || 0)
+                // offsetTop/Left, not style.top/left which can be 'auto' -> parseFloat NaN -> lost position.
+                top: event.group.element.parentElement.offsetTop,
+                left: event.group.element.parentElement.offsetLeft
             },
             index: event.group.delPanelIndex
         }


### PR DESCRIPTION
A set of related fixes for the group lifecycle (delete → re-insert → float → dock).

## Fixes
close #1048

- **Re-insert into an emptied group**: defer action-button state while a placeholder
  group is empty (avoids `[].every()` showing wrong buttons that stick), and restore
  the pre-delete width instead of collapsing to the ~100px minimum.
- **Dock a floating group back to grid**: re-render the origin group's action buttons,
  which were deferred while it sat empty as a placeholder.
- **Floating group close / re-insert**: closing a floating group now closes its panels
  individually, so external panel buttons stay highlight-synced; a re-added floating
  group gets its active panel set (no blank); a hidden→re-inserted floating group keeps
  its last size & position (offset-based capture, immune to `style:auto`).
- **Width after re-open + float/dock-back**: clear the stale `_pendingSize` left by the
  width restore, so a group resized after re-opening no longer snaps back to its old
  width on dock-back.
- **Re-open a panel while its group is floated**: route it into the floating group
  instead of resurrecting the hidden grid placeholder. This avoids forking one group
  into two (a grid copy + the float) — which collided on the float id and left the
  second floating group unable to dock back.

## Scope
DockView only, 3 JS files (`dockview-group.js`, `dockview-extensions.js`,
`dockview-panel.js`). Only the delete/re-insert/float/dock paths are touched; adding a
tab to an existing group and all non-floating paths are unchanged.

## Summary by Sourcery

Improve DockView group lifecycle behavior when deleting, re-inserting, floating, and docking groups to avoid placeholder glitches and stale layout state.

Bug Fixes:
- Route panels re-opened from a hidden grid placeholder into the corresponding floating group to prevent duplicate groups and docking failures.
- Restore pre-delete grid group width when re-inserting into an empty placeholder instead of collapsing to the minimum width, and clear any stale pending size so later dock operations do not snap back.
- Ensure action buttons for empty placeholder groups are deferred and correctly re-rendered once a panel is added or a floating group is docked back.
- Initialize newly created floating groups with an active panel so they are not shown blank on creation.
- When closing a floating group, close its panels individually so panel visibility events fire consistently and the group is removed via the standard empty-group path.
- Preserve floating group position and size across hide/re-insert operations by saving offsets via currentPosition instead of unreliable style-based values.

Enhancements:
- Add utilities to re-render group action button states when an empty placeholder becomes populated, keeping lock/minimize/maximize visibility in sync with options.