### PR TITLE
fix(DockView): restore a re-shown group's size only when collapsed to its minimum

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.21</Version>
+    <Version>10.0.22</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
+++ b/src/components/BootstrapBlazor.DockView/wwwroot/js/dockview-group.js
@@ -85,10 +85,15 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         }
     }
 
-    // Placeholder branch collapsed to width 0 in the saved layout; restore the pre-delete width (currentPosition)
-    // via initialWidth → setSize, else it re-shows at min ~100.
-    const restoreWidth = reusedEmptyGroup && group.api.location.type === 'grid'
-        ? panel.params?.currentPosition?.width : undefined;
+    // Restore a saved dimension only when the group collapsed to its minimum; if the structure already gave it a real
+    // size, restoring a stale saved value would shrink it and squeeze/blank a sibling.
+    let initialWidth, initialHeight;
+    if (reusedEmptyGroup && group.api.location.type === 'grid' && group.element.parentElement) {
+        const cp = panel.params?.currentPosition;
+        const { offsetWidth, offsetHeight } = group.element.parentElement;
+        if (cp?.width > offsetWidth && offsetWidth <= group.minimumWidth + 2) initialWidth = cp.width;
+        if (cp?.height > offsetHeight && offsetHeight <= group.minimumHeight + 2) initialHeight = cp.height;
+    }
     dockview.addPanel({
         id: panel.id,
         title: panel.title,
@@ -96,7 +101,8 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
         renderer: panel.renderer,
         component: panel.component,
         position: { referenceGroup: group, index: index || 0 },
-        initialWidth: restoreWidth > 0 ? restoreWidth : undefined,
+        initialWidth,
+        initialHeight,
         params: { ...panel.params, rect, packup, visible: true }
     })
 
@@ -108,8 +114,8 @@ const addPanelWidthGroupId = (dockview, panel, index) => {
     // Placeholder deferred its action states while empty (see resetActionStates); re-render now it has a panel.
     if (reusedEmptyGroup && group.api.location.type === 'grid') {
         reRenderActionStates(group);
-        // initialWidth left a _pendingSize; clear it so a later setVisible(true) (float->dock) won't replay this stale width.
-        if (restoreWidth > 0) group.api._pendingSize = undefined;
+        // The restore left a _pendingSize; clear it so a later setVisible(true) (float->dock) won't replay this stale size.
+        if (initialWidth > 0 || initialHeight > 0) group.api._pendingSize = undefined;
     }
 }
 


### PR DESCRIPTION
#Issues
close #1052 

Follow-up to #1047, which restored a re-opened group's width unconditionally and never restored height. In a left/right + nested (top/bottom) layout, re-showing a previously-closed group could then misbehave:

## Problem
- **The opposite side goes blank**: re-showing a group re-applied its *stale* saved width and shrank it; the freed space went to a sibling region that had no visible groups, so that whole side rendered blank (no content, though still draggable/operable).
- **Or the sibling gets squeezed to ~100px** when the stale saved width was larger than the group's current width.
- **Vertical groups stuck at ~100px**: groups in a top/bottom split came back at the minimum because height was never restored at all.

## Fix
Restore a saved dimension (width **and** height) only when the group is actually collapsed to its minimum (`offset <= group.minimum + 2`); if the layout already gave it a real size, keep it.

`.dv-view` is an unstyled absolute wrapper, so its offset size equals the splitview size exactly — at collapse that is the group's minimum, making the check reliable.

## Known limitation
Deleting both groups of one side in sequence then re-adding them can still squeeze one (the later-deleted group captured the full size while alone). Inherent to storing absolute sizes at delete time; a proportional / redistribute-on-re-add fix is deferred.

## Summary by Sourcery

Adjust DockView group size restoration when re-showing previously closed groups to avoid layout issues in nested grid splits.

Bug Fixes:
- Restore both width and height of re-shown groups only when they were previously collapsed to their minimum size, preventing sibling regions from being squeezed or rendered blank.
- Ensure pending size state is cleared after a conditional size restore so future visibility changes do not replay stale dimensions.

Enhancements:
- Add conditional logic for initial width and height when reusing empty grid groups based on current container size and group minimums.