### PR TITLE
feat(DockView): preventing access to objects after dispose

### DIFF
--- a/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.22</Version>
+    <Version>10.0.23</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
+++ b/src/components/BootstrapBlazor.DockView/Components/DockViewV2.razor.cs
@@ -179,6 +179,7 @@ public partial class DockViewV2
     private DockViewOptions? _options = null;
     private ConcurrentDictionary<string, DockViewComponentState> _componentStates = new();
     private string? _layoutConfig;
+    private bool _disposed;
 
     /// <summary>
     /// <inheritdoc/>
@@ -215,6 +216,11 @@ public partial class DockViewV2
     {
         await base.OnAfterRenderAsync(firstRender);
 
+        if (_disposed)
+        {
+            return;
+        }
+
         if (firstRender)
         {
             _layoutConfig = LayoutConfig;
@@ -232,7 +238,15 @@ public partial class DockViewV2
     /// <summary>
     /// <inheritdoc />
     /// </summary>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, GetDockViewConfig());
+    protected override Task InvokeInitAsync()
+    {
+        if (_disposed)
+        {
+            return Task.CompletedTask;
+        }
+
+        return InvokeVoidAsync("init", Id, Interop, GetDockViewConfig());
+    }
 
     private DockViewConfig GetDockViewConfig()
     {
@@ -494,6 +508,7 @@ public partial class DockViewV2
     {
         if (disposing)
         {
+            _disposed = true;
             ThemeProviderService.ThemeChangedAsync -= OnThemeChangedAsync;
         }
 


### PR DESCRIPTION
## Link issues
fixes #1053 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Prevent DockViewV2 from invoking JS initialization or post-render logic after the component has been disposed.