### PR TITLE
fix(Chart): stacked bar ShowDataLabel has overlapping text

### DIFF
--- a/src/components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
+++ b/src/components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.3</Version>
+    <Version>10.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
+++ b/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
@@ -371,6 +371,11 @@ const getChartOption = function (option) {
         }
     }
 
+    let showDataLabel = option.options.showDataLabel;
+    if (showDataLabel === true && option.options.x.stacked) {
+        showDataLabel = context => Number(context.dataset?.data[context.dataIndex]) !== 0;
+    }
+
     return {
         ...config,
         ...{
@@ -395,7 +400,7 @@ const getChartOption = function (option) {
                         anchor: option.options.anchor,
                         align: option.options.align,
                         formatter: option.options.formatter,
-                        display: option.options.showDataLabel,
+                        display: showDataLabel,
                         color: option.options.chartDataLabelColor,
                         font: {
                             weight: 'bold'


### PR DESCRIPTION
## Link issues
fixes #1057 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Resolve overlapping data labels in stacked bar charts by conditionally displaying labels only for non-zero bar values.