### PR TITLE
feat(Chart): add ShowTotalDataLabel parameter

### DIFF
--- a/src/components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
+++ b/src/components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.5</Version>
+    <Version>10.0.6</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
+++ b/src/components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.4</Version>
+    <Version>10.0.5</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
+++ b/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
@@ -392,6 +392,39 @@ const getChartOption = function (option) {
         showDataLabel = context => Number(context.dataset?.data[context.dataIndex]) !== 0;
     }
 
+    const datalabels = {
+        anchor: option.options.anchor,
+        align: option.options.align,
+        formatter: option.options.formatter,
+        display: showDataLabel,
+        color: option.options.chartDataLabelColor,
+        font: {
+            weight: 'bold'
+        }
+    };
+
+    if (option.options.showTotalDataLabel && option.options.x.stacked) {
+        const lastVisibleIndex = chart => {
+            let last = -1;
+            chart.data.datasets.forEach((v, index) => {
+                if (chart.isDatasetVisible(index)) {
+                    last = index;
+                }
+            });
+            return last;
+        };
+        datalabels.labels = {
+            value: {},
+            total: {
+                anchor: 'end',
+                align: 'end',
+                display: context => context.datasetIndex === lastVisibleIndex(context.chart),
+                formatter: (value, context) => context.chart.data.datasets.reduce(
+                    (total, v, index) => context.chart.isDatasetVisible(index) ? total + (Number(v.data[context.dataIndex]) || 0) : total, 0)
+            }
+        };
+    }
+
     return {
         ...config,
         ...{
@@ -412,16 +445,7 @@ const getChartOption = function (option) {
                         display: option.options.title != null,
                         text: option.options.title
                     },
-                    datalabels: {
-                        anchor: option.options.anchor,
-                        align: option.options.align,
-                        formatter: option.options.formatter,
-                        display: showDataLabel,
-                        color: option.options.chartDataLabelColor,
-                        font: {
-                            weight: 'bold'
-                        }
-                    },
+                    datalabels: datalabels,
                     customCanvasBackgroundColor: {
                         color: option.options.canvasBackgroundColor,
                     }

--- a/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
+++ b/src/components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
@@ -127,6 +127,9 @@ const getChartOption = function (option) {
                 text: option.options.x.title
             },
             stacked: option.options.x.stacked,
+            ticks: {
+                autoSkip: option.options.x.autoSkip
+            },
             grid: {
                 display: option.options.showXLine
             }
@@ -139,6 +142,9 @@ const getChartOption = function (option) {
             },
             stacked: option.options.x.stacked,
             position: option.options.y.position,
+            ticks: {
+                autoSkip: option.options.y.autoSkip
+            },
             grid: {
                 display: option.options.showYLine
             }
@@ -359,6 +365,7 @@ const getChartOption = function (option) {
             stacked: option.options.x.stacked,
             position: option.options.y2.position,
             ticks: {
+                autoSkip: option.options.y2.autoSkip,
                 max: option.options.y2.TicksMax,
                 min: option.options.y2.TicksMin
             }

--- a/src/components/BootstrapBlazor.Chart/Components/Chart/ChartAxes.cs
+++ b/src/components/BootstrapBlazor.Chart/Components/Chart/ChartAxes.cs
@@ -27,6 +27,11 @@ public class ChartAxes
     public bool Stacked { get; set; }
 
     /// <summary>
+    /// 获得/设置 是否自动跳过刻度标签 默认 true 容器宽度不足时自动隐藏部分标签避免重叠 设置 false 时始终显示全部标签
+    /// </summary>
+    public bool AutoSkip { get; set; } = true;
+
+    /// <summary>
     /// 获得/设置 比例最小步长/大小 默认 0
     /// </summary>
     public int TicksMin { get; set; } = 0;

--- a/src/components/BootstrapBlazor.Chart/Components/Chart/ChartOptions.cs
+++ b/src/components/BootstrapBlazor.Chart/Components/Chart/ChartOptions.cs
@@ -219,6 +219,11 @@ public class ChartOptions
     public bool ShowDataLabel { get; set; }
 
     /// <summary>
+    /// 获得/设置 堆叠模式下是否在每个柱条顶部显示总计数据标签 默认 false
+    /// </summary>
+    public bool ShowTotalDataLabel { get; set; }
+
+    /// <summary>
     /// 获得/设置 是否单独设置柱状图颜色
     /// </summary>
     public bool BarColorSeparately { get; set; }


### PR DESCRIPTION
## Link issues
fixes #1061 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add support for showing total data labels on stacked charts.

New Features:
- Introduce a ShowTotalDataLabel option in ChartOptions to control display of total labels on stacked bar chart columns.

Enhancements:
- Refactor chart datalabel configuration to reuse a shared datalabels object and extend it with total label behavior when enabled.