### PR TITLE
fix(Markdown): resolve throw exception in Modal component

### DIFF
--- a/src/components/BootstrapBlazor.Markdown/BootstrapBlazor.Markdown.csproj
+++ b/src/components/BootstrapBlazor.Markdown/BootstrapBlazor.Markdown.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
+    <Version>10.0.1</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <PackageTags>Bootstrap Blazor WebAssembly wasm UI Components Markdown</PackageTags>
     <Description>Bootstrap UI components extensions of Markdown</Description>
   </PropertyGroup>

--- a/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
+++ b/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
@@ -3,6 +3,7 @@ import '../../lib/tui.editor/zh-cn.min.js'
 import '../../lib/tui.highlight/toastui-editor-plugin-code-syntax-highlight-all.min.js'
 import { addLink } from '../../../BootstrapBlazor/modules/utility.js'
 import Data from '../../../BootstrapBlazor/modules/data.js'
+import EventHandler from '../../../BootstrapBlazor/modules/event-handler.js'
 
 export async function init(id, invoker, options, callback) {
     await addLink('./_content/BootstrapBlazor.Markdown/css/bootstrap.blazor.markdown.min.css')
@@ -29,8 +30,8 @@ export async function init(id, invoker, options, callback) {
 
     md._modal = el.closest('.modal')
     if (md._modal) {
-        md._modalHideHandler = () => disposeEditor(id)
-        md._modal.addEventListener('hide.bs.modal', md._modalHideHandler)
+        md._modalHideHandler = () => dispose(id)
+        EventHandler.on(md._modal, 'hide.bs.modal', md._modalHideHandler)
     }
 }
 
@@ -48,16 +49,14 @@ export function invoke(id, method, parameters) {
 }
 
 export function dispose(id) {
-    disposeEditor(id)
-}
-
-function disposeEditor(id) {
     const md = Data.get(id)
-    if (!md) return;
-    if (md._modal && md._modalHideHandler) {
-        md._modal.removeEventListener('hide.bs.modal', md._modalHideHandler)
-    }
     Data.remove(id)
-    md._editor.off('blur')
-    md._editor.destroy()
+    if (md) {
+        const { _modal, _modalHideHandler, _editor } = md;
+        if (_modal && _modalHideHandler) {
+            EventHandler.off(_modal, 'hide.bs.modal', _modalHideHandler)
+        }
+        _editor.off('blur')
+        _editor.destroy()
+    }
 }

--- a/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
+++ b/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
@@ -53,6 +53,7 @@ export function dispose(id) {
 
 function disposeEditor(id) {
     const md = Data.get(id)
+    if (!md) return;
     if (md._modal && md._modalHideHandler) {
         md._modal.removeEventListener('hide.bs.modal', md._modalHideHandler)
     }

--- a/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
+++ b/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
@@ -1,4 +1,4 @@
-﻿import '../../lib/tui.editor/toastui-editor-all.min.js'
+import '../../lib/tui.editor/toastui-editor-all.min.js'
 import '../../lib/tui.editor/zh-cn.min.js'
 import '../../lib/tui.highlight/toastui-editor-plugin-code-syntax-highlight-all.min.js'
 import { addLink } from '../../../BootstrapBlazor/modules/utility.js'
@@ -26,6 +26,12 @@ export async function init(id, invoker, options, callback) {
         const html = md._editor.getHTML()
         md._invoker.invokeMethodAsync(md._invokerMethod, [val, html])
     })
+
+    md._modal = el.closest('.modal')
+    if (md._modal) {
+        md._modalHideHandler = () => disposeEditor(id)
+        md._modal.addEventListener('hide.bs.modal', md._modalHideHandler)
+    }
 }
 
 export function update(id, val) {
@@ -42,7 +48,14 @@ export function invoke(id, method, parameters) {
 }
 
 export function dispose(id) {
+    disposeEditor(id)
+}
+
+function disposeEditor(id) {
     const md = Data.get(id)
+    if (md._modal && md._modalHideHandler) {
+        md._modal.removeEventListener('hide.bs.modal', md._modalHideHandler)
+    }
     Data.remove(id)
     md._editor.off('blur')
     md._editor.destroy()

--- a/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
+++ b/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
@@ -3,7 +3,6 @@ import '../../lib/tui.editor/zh-cn.min.js'
 import '../../lib/tui.highlight/toastui-editor-plugin-code-syntax-highlight-all.min.js'
 import { addLink } from '../../../BootstrapBlazor/modules/utility.js'
 import Data from '../../../BootstrapBlazor/modules/data.js'
-import EventHandler from '../../../BootstrapBlazor/modules/event-handler.js'
 
 export async function init(id, invoker, options, callback) {
     await addLink('./_content/BootstrapBlazor.Markdown/css/bootstrap.blazor.markdown.min.css')
@@ -31,7 +30,7 @@ export async function init(id, invoker, options, callback) {
     md._modal = el.closest('.modal')
     if (md._modal) {
         md._modalHideHandler = () => disposeEditor(id)
-        EventHandler.on(md._modal, 'hidden.bs.modal', md._modalHideHandler)
+        md._modal.addEventListener('hide.bs.modal', md._modalHideHandler)
     }
 }
 
@@ -54,16 +53,11 @@ export function dispose(id) {
 
 function disposeEditor(id) {
     const md = Data.get(id)
-    Data.remove(id)
-
-    if (md) {
-        const { _modal, _editor, _modalHideHandler } = md;
-        if (_modal && _modalHideHandler) {
-            EventHandler.off(_modal, 'hidden.bs.modal', _modalHideHandler)
-        }
-        if (_editor) {
-            _editor.off('blur')
-            _editor.destroy()
-        }
+    if (!md) return;
+    if (md._modal && md._modalHideHandler) {
+        md._modal.removeEventListener('hide.bs.modal', md._modalHideHandler)
     }
+    Data.remove(id)
+    md._editor.off('blur')
+    md._editor.destroy()
 }

--- a/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
+++ b/src/components/BootstrapBlazor.Markdown/Components/Markdown/Markdown.razor.js
@@ -3,6 +3,7 @@ import '../../lib/tui.editor/zh-cn.min.js'
 import '../../lib/tui.highlight/toastui-editor-plugin-code-syntax-highlight-all.min.js'
 import { addLink } from '../../../BootstrapBlazor/modules/utility.js'
 import Data from '../../../BootstrapBlazor/modules/data.js'
+import EventHandler from '../../../BootstrapBlazor/modules/event-handler.js'
 
 export async function init(id, invoker, options, callback) {
     await addLink('./_content/BootstrapBlazor.Markdown/css/bootstrap.blazor.markdown.min.css')
@@ -30,7 +31,7 @@ export async function init(id, invoker, options, callback) {
     md._modal = el.closest('.modal')
     if (md._modal) {
         md._modalHideHandler = () => disposeEditor(id)
-        md._modal.addEventListener('hide.bs.modal', md._modalHideHandler)
+        EventHandler.on(md._modal, 'hidden.bs.modal', md._modalHideHandler)
     }
 }
 
@@ -53,11 +54,16 @@ export function dispose(id) {
 
 function disposeEditor(id) {
     const md = Data.get(id)
-    if (!md) return;
-    if (md._modal && md._modalHideHandler) {
-        md._modal.removeEventListener('hide.bs.modal', md._modalHideHandler)
-    }
     Data.remove(id)
-    md._editor.off('blur')
-    md._editor.destroy()
+
+    if (md) {
+        const { _modal, _editor, _modalHideHandler } = md;
+        if (_modal && _modalHideHandler) {
+            EventHandler.off(_modal, 'hidden.bs.modal', _modalHideHandler)
+        }
+        if (_editor) {
+            _editor.off('blur')
+            _editor.destroy()
+        }
+    }
 }


### PR DESCRIPTION
fix:修复Markdown组件在编辑弹窗中，关闭弹窗时浏览器控制台报错找不到节点元素的问题

## Link issues
fixes #1091

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## 问题描述 / Problem Description
当组件在弹窗中使用时，由于弹窗先销毁，然后再销毁组件，导致组件在销毁时找不到对应的元素

## 解决方案 / Solution
在组件初始化时，将组件的销毁与弹窗的销毁绑定

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Prevent console errors caused by the Markdown component trying to dispose after its DOM element has already been destroyed when used inside a modal dialog.