### PR TITLE
feat(Html2Pdf): bump PuppeteerSharp to 25.6.0

### DIFF
--- a/src/components/BootstrapBlazor.Html2Pdf/BootstrapBlazor.Html2Pdf.csproj
+++ b/src/components/BootstrapBlazor.Html2Pdf/BootstrapBlazor.Html2Pdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.13</Version>
+    <Version>10.0.14</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Html2Pdf/BootstrapBlazor.Html2Pdf.csproj
+++ b/src/components/BootstrapBlazor.Html2Pdf/BootstrapBlazor.Html2Pdf.csproj
@@ -22,15 +22,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="PuppeteerSharp" Version="25.5.0" />
+    <PackageReference Include="PuppeteerSharp" Version="25.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="PuppeteerSharp" Version="25.5.0" />
+    <PackageReference Include="PuppeteerSharp" Version="25.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="PuppeteerSharp" Version="25.5.0" />
+    <PackageReference Include="PuppeteerSharp" Version="25.6.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Link issues
fixes #1097 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Build:
- Update BootstrapBlazor.Html2Pdf project configuration to reference PuppeteerSharp 25.6.0.