### PR TITLE
feat(Dom2Image): update SnapDOM version to 2.24.12

### DIFF
--- a/src/components/BootstrapBlazor.Dom2Image/BootstrapBlazor.Dom2Image.csproj
+++ b/src/components/BootstrapBlazor.Dom2Image/BootstrapBlazor.Dom2Image.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.0.3</Version>
+    <Version>10.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/components/BootstrapBlazor.Dom2Image/wwwroot/lib/snapdom.mjs
+++ b/src/components/BootstrapBlazor.Dom2Image/wwwroot/lib/snapdom.mjs
@@ -1,6 +1,6 @@
 /*
 * SnapDOM
-* v2.24.10
+* v2.24.12
 * Author: Juan Martin Muda
 * License: MIT
 */


### PR DESCRIPTION
## Changes

- update the bundled SnapDOM ESM artifact from v2.24.10 to v2.24.12
- bump BootstrapBlazor.Dom2Image from 10.0.3 to 10.0.4

Closes #1113

## Summary by Sourcery

Enhancements:
- Update the Dom2Image component to use SnapDOM v2.24.12 and release BootstrapBlazor.Dom2Image v10.0.4.