### PR TITLE
feat(OpcUa): bump version 10.0.2

### DIFF
--- a/src/extensions/BootstrapBlazor.OpcUa/BootstrapBlazor.OpcUa.csproj
+++ b/src/extensions/BootstrapBlazor.OpcUa/BootstrapBlazor.OpcUa.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>10.0.1</Version>
+    <Version>10.0.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Link issues
fixes #1121

## Summary By Copilot

Bump `BootstrapBlazor.OpcUa` from version 10.0.1 to 10.0.2 to publish the client API naming changes from #1120.

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

This only updates the package version.

## Verification
- [ ] Manual (required)
- [x] Automated

- built BootstrapBlazor.OpcUa for all target frameworks with no warnings or errors
- passed all 5 UnitTestOpcUa tests on `net10.0`

## Packaging changes reviewed?
- [x] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Build:
- Bump the BootstrapBlazor.OpcUa package version to 10.0.2.